### PR TITLE
docs: add OpenCode setup video

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ To use this gateway with [OpenCode](https://opencode.ai), add the following prov
 
 For more details on OpenCode configuration, see the [OpenCode Config Documentation](https://opencode.ai/docs/config/).
 
-https://github.com/if414013/rkgw/raw/main/docs/images-and-videos/opencode.mov
+https://github.com/user-attachments/assets/7a3ab9ba-15b4-4b96-95df-158602ed08b0
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Adds placeholder for OpenCode setup video in README

**Note:** Drag and drop the `opencode.mov` file into this PR description to get an embeddable GitHub URL, then update the README with that URL.