### PR TITLE
docs: add video section for Claude Code CLI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ https://github.com/user-attachments/assets/7a3ab9ba-15b4-4b96-95df-158602ed08b0
 <details>
 <summary>View Claude Code CLI configuration</summary>
 
-https://github.com/user-attachments/assets/placeholder-claude-code-video
+https://github.com/user-attachments/assets/f404096e-b326-41e5-a4b3-3f94a73d2ece
 
 To use this gateway with [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code), set the following environment variables:
 


### PR DESCRIPTION
## Summary
- Adds a video placeholder in the Claude Code CLI Setup section of the README
- Mirrors the video format already used in the OpenCode Setup section

**Note:** Upload the video in the comments below, then the placeholder link will be updated with the actual video URL.