### PR TITLE
docs: format README tables, lists, and update OpenCode config

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,18 @@ https://github.com/user-attachments/assets/7a3ab9ba-15b4-4b96-95df-158602ed08b0
         "modalities": {
           "input": ["text", "image"],
           "output": ["text"]
+        },
+        "variants": {
+          "low": {
+            "thinkingConfig": {
+              "thinkingBudget": 4096
+            }
+          },
+          "max": {
+            "thinkingConfig": {
+              "thinkingBudget": 32768
+            }
+          }
         }
       },
       "claude-opus-4.6": {
@@ -239,6 +251,14 @@ https://github.com/user-attachments/assets/7a3ab9ba-15b4-4b96-95df-158602ed08b0
         "modalities": {
           "input": ["text", "image"],
           "output": ["text"]
+        },
+        "variants": {
+          "low": {
+            "thinkingConfig": { "type": "adaptive", "effort": "low" }
+          },
+          "max": {
+            "thinkingConfig": { "type": "adaptive", "effort": "max" }
+          }
         }
       },
       "claude-sonnet-4": {


### PR DESCRIPTION
## Summary

- Fixes markdown table alignment across all tables (models, features, config, env vars)
- Adds missing blank lines before bulleted lists for proper markdown rendering
- Updates OpenCode configuration example with new models (Claude Opus 4.6) and adds `limit` fields with context/output token counts
- Switches italic syntax from `*...*` to `_..._` for consistency