### PR TITLE
Update README to use port 8000 and add Zed config

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,8 @@ export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 <details>
 <summary>View Zed Editor configuration</summary>
 
-To use this gateway with the [Zed Editor](https://zed.dev/)'s ACP Claude Agent, add the following configuration to your Zed settings file at `~/.config/zed/settings.json`:
+To use this gateway with the [Zed Editor](https://zed.dev/)'s Agent Client Protocol (ACP)
+ Claude Agent, add the following configuration to your Zed settings file at `~/.config/zed/settings.json`:
 
 ```json
 {


### PR DESCRIPTION
- Align OpenCode Config to use port 8000 since it is the default port.
- Add Zed Editor config to allow the ACP Claude Code instance to utilise Kiro-Gateway.