### PR TITLE
fix: UTF-8 safe string truncation in tool debug logs

### DIFF
--- a/src/streaming/mod.rs
+++ b/src/streaming/mod.rs
@@ -337,7 +337,8 @@ impl ToolCallAccumulator {
             "Finalizing tool '{}' with raw arguments: {}",
             tool.name,
             if tool.input_str.len() > 200 {
-                format!("{}...", &tool.input_str[..200])
+                let end = tool.input_str.floor_char_boundary(200);
+                format!("{}...", &tool.input_str[..end])
             } else {
                 tool.input_str.clone()
             }
@@ -369,7 +370,8 @@ impl ToolCallAccumulator {
                         tool.name,
                         e,
                         if tool.input_str.len() > 200 {
-                            format!("{}...", &tool.input_str[..200])
+                            let end = tool.input_str.floor_char_boundary(200);
+                            format!("{}...", &tool.input_str[..end])
                         } else {
                             tool.input_str.clone()
                         }


### PR DESCRIPTION
## Summary

- Fixes a panic in `streaming/mod.rs` at lines 340 and 372 where `&tool.input_str[..200]` slices at a raw byte index. When tool arguments contain multi-byte UTF-8 characters (common with MCP tool calls — file paths, JSON with unicode, emoji, CJK text, etc.), byte index 200 can land in the middle of a character, causing a `byte index is not a char boundary` panic.
- The panic kills the tokio task handling that streaming request, dropping the connection mid-stream for the client.
- Replaced with `floor_char_boundary(200)` which finds the nearest valid UTF-8 character boundary at or before the target index. This is only used for debug/warning log truncation, so no functional behavior changes.

## Test plan

- [x] `cargo test --lib` — all 240 tests pass
- [x] `cargo clippy` — no new warnings
- [x] `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)