### PR TITLE
fix: use ContentBlock array format for Kiro API content fields

### DIFF
--- a/backend/src/converters/core.rs
+++ b/backend/src/converters/core.rs
@@ -968,6 +968,12 @@ pub fn merge_adjacent_messages(messages: Vec<UnifiedMessage>) -> Vec<UnifiedMess
 // Kiro History Building
 // ==================================================================================================
 
+/// Wraps a text string into the Kiro ContentBlock array format:
+/// `[{"type": "text", "text": "..."}]`
+pub fn kiro_text_content(text: &str) -> Value {
+    json!([{"type": "text", "text": text}])
+}
+
 /// Builds history array for Kiro API from unified messages.
 ///
 /// Kiro API expects history as paired turns: each entry must have both
@@ -1008,7 +1014,7 @@ fn build_kiro_user_input(msg: &UnifiedMessage, model_id: &str) -> Value {
     }
 
     let mut user_input = json!({
-        "content": content,
+        "content": kiro_text_content(&content),
         "modelId": model_id,
         "origin": "AI_EDITOR",
     });
@@ -1066,7 +1072,7 @@ fn build_kiro_assistant_response(msg: &UnifiedMessage) -> Value {
         content = "(empty)".to_string();
     }
 
-    let mut assistant_response = json!({"content": content});
+    let mut assistant_response = json!({"content": kiro_text_content(&content)});
 
     let tool_uses = extract_tool_uses_from_message(&msg.content, &msg.tool_calls);
     if !tool_uses.is_empty() {
@@ -1079,7 +1085,7 @@ fn build_kiro_assistant_response(msg: &UnifiedMessage) -> Value {
 /// Creates a synthetic user input for pairing with orphaned assistant messages.
 pub fn synthetic_user_input(model_id: &str) -> Value {
     json!({
-        "content": "(continued)",
+        "content": kiro_text_content("(continued)"),
         "modelId": model_id,
         "origin": "AI_EDITOR",
     })
@@ -1087,7 +1093,7 @@ pub fn synthetic_user_input(model_id: &str) -> Value {
 
 /// Creates a synthetic assistant response for pairing with trailing user messages.
 fn synthetic_assistant_response() -> Value {
-    json!({"content": "(continued)"})
+    json!({"content": kiro_text_content("(continued)")})
 }
 
 /// Pairs history entries into Kiro Turn objects.
@@ -1764,8 +1770,8 @@ mod tests {
         assert_eq!(history.len(), 1);
         assert!(history[0]["userInputMessage"].is_object());
         assert!(history[0]["assistantResponseMessage"].is_object());
-        assert_eq!(history[0]["userInputMessage"]["content"], "Hello");
-        assert_eq!(history[0]["assistantResponseMessage"]["content"], "Hi there");
+        assert_eq!(history[0]["userInputMessage"]["content"][0]["text"], "Hello");
+        assert_eq!(history[0]["assistantResponseMessage"]["content"][0]["text"], "Hi there");
     }
 
     #[test]
@@ -1778,10 +1784,10 @@ mod tests {
         ];
         let history = build_kiro_history(&messages, "claude-sonnet-4");
         assert_eq!(history.len(), 2);
-        assert_eq!(history[0]["userInputMessage"]["content"], "Q1");
-        assert_eq!(history[0]["assistantResponseMessage"]["content"], "A1");
-        assert_eq!(history[1]["userInputMessage"]["content"], "Q2");
-        assert_eq!(history[1]["assistantResponseMessage"]["content"], "A2");
+        assert_eq!(history[0]["userInputMessage"]["content"][0]["text"], "Q1");
+        assert_eq!(history[0]["assistantResponseMessage"]["content"][0]["text"], "A1");
+        assert_eq!(history[1]["userInputMessage"]["content"][0]["text"], "Q2");
+        assert_eq!(history[1]["assistantResponseMessage"]["content"][0]["text"], "A2");
     }
 
     #[test]
@@ -1795,11 +1801,11 @@ mod tests {
         let history = build_kiro_history(&messages, "claude-sonnet-4");
         assert_eq!(history.len(), 2);
         // First turn: synthetic user + orphaned assistant
-        assert_eq!(history[0]["userInputMessage"]["content"], "(continued)");
-        assert_eq!(history[0]["assistantResponseMessage"]["content"], "Session started");
+        assert_eq!(history[0]["userInputMessage"]["content"][0]["text"], "(continued)");
+        assert_eq!(history[0]["assistantResponseMessage"]["content"][0]["text"], "Session started");
         // Second turn: normal pair
-        assert_eq!(history[1]["userInputMessage"]["content"], "Hi");
-        assert_eq!(history[1]["assistantResponseMessage"]["content"], "Hello");
+        assert_eq!(history[1]["userInputMessage"]["content"][0]["text"], "Hi");
+        assert_eq!(history[1]["assistantResponseMessage"]["content"][0]["text"], "Hello");
     }
 
     #[test]
@@ -1812,10 +1818,10 @@ mod tests {
         ];
         let history = build_kiro_history(&messages, "claude-sonnet-4");
         assert_eq!(history.len(), 2);
-        assert_eq!(history[0]["userInputMessage"]["content"], "Hello");
-        assert_eq!(history[0]["assistantResponseMessage"]["content"], "Hi");
-        assert_eq!(history[1]["userInputMessage"]["content"], "Follow up");
-        assert_eq!(history[1]["assistantResponseMessage"]["content"], "(continued)");
+        assert_eq!(history[0]["userInputMessage"]["content"][0]["text"], "Hello");
+        assert_eq!(history[0]["assistantResponseMessage"]["content"][0]["text"], "Hi");
+        assert_eq!(history[1]["userInputMessage"]["content"][0]["text"], "Follow up");
+        assert_eq!(history[1]["assistantResponseMessage"]["content"][0]["text"], "(continued)");
     }
 
     #[test]
@@ -1830,8 +1836,8 @@ mod tests {
         let messages = vec![make_user_msg("Hello")];
         let history = build_kiro_history(&messages, "claude-sonnet-4");
         assert_eq!(history.len(), 1);
-        assert_eq!(history[0]["userInputMessage"]["content"], "Hello");
-        assert_eq!(history[0]["assistantResponseMessage"]["content"], "(continued)");
+        assert_eq!(history[0]["userInputMessage"]["content"][0]["text"], "Hello");
+        assert_eq!(history[0]["assistantResponseMessage"]["content"][0]["text"], "(continued)");
     }
 
     #[test]
@@ -1839,8 +1845,8 @@ mod tests {
         let messages = vec![make_assistant_msg("I'm here")];
         let history = build_kiro_history(&messages, "claude-sonnet-4");
         assert_eq!(history.len(), 1);
-        assert_eq!(history[0]["userInputMessage"]["content"], "(continued)");
-        assert_eq!(history[0]["assistantResponseMessage"]["content"], "I'm here");
+        assert_eq!(history[0]["userInputMessage"]["content"][0]["text"], "(continued)");
+        assert_eq!(history[0]["assistantResponseMessage"]["content"][0]["text"], "I'm here");
     }
 
     #[test]

--- a/backend/src/converters/openai_to_kiro.rs
+++ b/backend/src/converters/openai_to_kiro.rs
@@ -15,10 +15,10 @@ use super::core::{
     build_kiro_history, convert_images_to_kiro_format, convert_tool_results_to_kiro_format,
     convert_tools_to_kiro_format, ensure_assistant_before_tool_results,
     extract_images_from_content, extract_text_content, extract_tool_results_from_content,
-    get_thinking_system_prompt_addition, inject_thinking_tags, merge_adjacent_messages,
-    process_tools_with_long_descriptions, strip_all_tool_content, synthetic_user_input,
-    ContentBlock, KiroPayloadResult, MessageContent, ToolCall, ToolFunction, ToolResult,
-    UnifiedMessage, UnifiedTool,
+    get_thinking_system_prompt_addition, inject_thinking_tags, kiro_text_content,
+    merge_adjacent_messages, process_tools_with_long_descriptions, strip_all_tool_content,
+    synthetic_user_input, ContentBlock, KiroPayloadResult, MessageContent, ToolCall,
+    ToolFunction, ToolResult, UnifiedMessage, UnifiedTool,
 };
 
 // ==================================================================================================
@@ -458,7 +458,7 @@ pub fn build_kiro_payload_core(
         final_history.push(json!({
             "userInputMessage": synthetic_user_input(model_id),
             "assistantResponseMessage": {
-                "content": current_content
+                "content": kiro_text_content(&current_content)
             }
         }));
         current_content = "Continue".to_string();
@@ -513,7 +513,7 @@ pub fn build_kiro_payload_core(
 
     // Build userInputMessage
     let mut user_input_message = json!({
-        "content": current_content,
+        "content": kiro_text_content(&current_content),
         "modelId": model_id,
         "origin": "AI_EDITOR",
     });
@@ -798,7 +798,7 @@ mod tests {
             .is_some());
         assert!(
             payload["conversationState"]["currentMessage"]["userInputMessage"]["content"]
-                .as_str()
+                .as_array()
                 .is_some()
         );
     }
@@ -850,11 +850,11 @@ mod tests {
         let payload_result = result.unwrap();
         let payload = payload_result.payload;
 
-        // System prompt should be included in the content
-        let content = payload["conversationState"]["currentMessage"]["userInputMessage"]["content"]
+        // System prompt should be included in the content (now array of ContentBlocks)
+        let content_text = payload["conversationState"]["currentMessage"]["userInputMessage"]["content"][0]["text"]
             .as_str()
             .unwrap();
-        assert!(content.contains("You are helpful"));
+        assert!(content_text.contains("You are helpful"));
     }
 
     #[test]
@@ -1045,9 +1045,14 @@ mod tests {
         let mut found_tool_text = false;
         for msg in history_arr {
             if let Some(assistant_msg) = msg.get("assistantResponseMessage") {
-                let content = assistant_msg["content"].as_str().unwrap_or("");
-                if content.contains("[Tool: Read") {
-                    found_tool_text = true;
+                // Content is now an array of ContentBlocks
+                if let Some(blocks) = assistant_msg["content"].as_array() {
+                    for block in blocks {
+                        let text = block["text"].as_str().unwrap_or("");
+                        if text.contains("[Tool: Read") {
+                            found_tool_text = true;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes HTTP 400 `Improperly formed request` (ValidationException) on every `generateAssistantResponse` request. The Kiro API expects `content` fields as arrays of ContentBlock objects, but the converter was sending plain strings.

## Root Cause

The typed `KiroRequest` model defines `content: Vec<ContentBlock>` which serializes to `[{"type": "text", "text": "..."}]`. The mock server also uses this format. But `build_kiro_payload_core` and `build_kiro_history` were building `"content": "plain string"` — causing the API to reject every request with a ValidationException.

This was the remaining cause of the 400 after PR #17 fixed turn pairing and system prompt injection.

## Changes

- Added `kiro_text_content()` helper in `core.rs` to centralize the `[{"type": "text", "text": "..."}]` format and eliminate duplication
- Fixed `content` in `currentMessage.userInputMessage` (openai_to_kiro.rs)
- Fixed `content` in assistant-continuation history entry (openai_to_kiro.rs)
- Fixed `content` in `build_kiro_user_input` and `build_kiro_assistant_response` (core.rs)
- Fixed `content` in `synthetic_user_input` and `synthetic_assistant_response` (core.rs)
- Updated all 9 affected tests to assert the new array format

## Testing

All 403 tests pass.