### PR TITLE
chore: improve .claude/ skills per Anthropic best practices

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,13 +7,14 @@ This directory contains the multi-agent workflow system for the rkgw Gateway. Se
 ```
 .claude/
 ├── settings.local.json          # Plugin toggles, MCP servers, env vars
-├── agents/                      # 7 agent definitions (domain-specific AI roles)
+├── agents/                      # 8 agent definitions (domain-specific AI roles)
 │   ├── scrum-master.md          # Workflow coordinator (orchestrates all agents)
 │   ├── rust-backend-engineer.md # Axum/Tokio backend (converters, auth, streaming)
 │   ├── react-frontend-engineer.md # React 19 web UI (pages, SSE, CRT aesthetic)
 │   ├── devops-engineer.md       # Docker, nginx, deployment, certs
 │   ├── backend-qa.md            # Rust unit/integration tests
 │   ├── frontend-qa.md           # Playwright E2E tests
+│   ├── conductor-validator.md   # Conductor artifact auditor (read-only)
 │   └── document-writer.md       # Notion, Slack, documentation
 ├── skills/                      # 16 invocable skills (/skill-name)
 │   ├── conductor-*/             # 6 project management skills (tracks, plans, status)

--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -1,0 +1,65 @@
+# Backend Rules
+
+Applies to files in `backend/`.
+
+## Stack
+
+- Rust (edition 2021) + Axum 0.7 + Tokio
+- sqlx 0.8 (PostgreSQL, compile-time checked queries)
+- tracing for structured logging
+- thiserror + anyhow for error handling
+
+## Build & Check
+
+```bash
+cd backend && cargo build              # debug build
+cd backend && cargo clippy             # lint — fix ALL warnings before committing
+cd backend && cargo fmt                # format
+cd backend && cargo test --lib         # unit tests
+```
+
+## Import Ordering
+
+Group imports with blank lines between groups:
+1. `std` — standard library
+2. External crates — alphabetical order
+3. `crate::` — internal modules
+
+## Error Handling
+
+- Define error enums with `thiserror` in `error.rs` per module
+- Use `anyhow::Result` with `.context()` for error propagation
+- `ApiError` implements `IntoResponse` for HTTP error mapping
+- Never use `.unwrap()` in production code — use `.context("reason")?`
+
+## Logging
+
+Use `tracing` macros with structured fields:
+```rust
+debug!(model = %model_id, "Processing request");
+info!(tokens = count, "Request completed");
+error!(error = ?err, "Failed to process");
+```
+- Use `%` for Display, `?` for Debug formatting
+- Include relevant context fields, not just messages
+
+## Testing
+
+- Unit tests in `#[cfg(test)] mod tests` at the bottom of each file
+- Naming: `test_<function>_<scenario>`
+- Async tests: `#[tokio::test]`
+- Helper configs: `create_test_config()` / `Config::with_defaults()`
+- Feature-gated: `#[cfg(any(test, feature = "test-utils"))]`
+- Run `cargo test --lib` before committing
+
+## Model Resolution
+
+- Never hardcode model IDs — always use `resolver.rs` for model name mapping
+- Model metadata cached via `ModelCache` with TTL
+
+## Key Patterns
+
+- `Arc<RwLock<T>>` for shared mutable state in AppState
+- `DashMap` for concurrent caches (API keys, sessions, tokens)
+- Streaming via `async-stream` crate — watch for borrow checker pitfalls
+- Serde: use `#[serde(rename_all = "snake_case")]` consistently; check `#[serde(rename = "...")]` on individual fields

--- a/.claude/skills/conductor-implement/SKILL.md
+++ b/.claude/skills/conductor-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conductor-implement
-description: Execute tasks from a track's plan with flexible TDD and optional team delegation.
+description: Execute tasks from a track's plan with flexible TDD and optional team delegation. Use when user says 'start working on track', 'implement next task', 'begin phase', 'pick up where I left off', or 'delegate task'. Do NOT use for building features from scratch without a track (use team-feature).
 argument-hint: "<track-id> [--phase N] [--task N.M] [--delegate]"
 allowed-tools:
   - Bash
@@ -16,6 +16,15 @@ allowed-tools:
 # Conductor Implement
 
 Execute implementation tasks from a track's phased plan. Supports direct execution (self) or delegation to specialized agents. Handles TDD policy, verification, commits, and status tracking.
+
+## Critical Constraints
+
+- **Never auto-commit** — always suggest a commit message and wait for explicit user approval before committing
+- **Phase gates** — STOP and wait for explicit user approval between phases; this approval gate is mandatory
+- **Branch required** — refuse to execute if on the `main` branch; create or switch to the track's feature branch first
+- **One question per turn** — never batch multiple questions together
+- **Mark tasks `[~]` when starting, `[x]` when done** — if implementation fails, revert the marker from `[~]` back to `[ ]`
+- **Never force-push or reset** — only additive git operations; never use `git reset --hard` or `git push --force`
 
 ---
 

--- a/.claude/skills/conductor-implement/references/verify.sh
+++ b/.claude/skills/conductor-implement/references/verify.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# verify.sh — Run all quality checks for the rkgw project.
+#
+# Usage:
+#   ./verify.sh              # Check all services (backend + frontend)
+#   ./verify.sh backend      # Check backend only
+#   ./verify.sh frontend     # Check frontend only
+#   ./verify.sh all          # Check all services (explicit)
+#
+# Exit codes:
+#   0 — All checks passed
+#   1 — One or more checks failed
+#   2 — Invalid usage or missing project directory
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Color support
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]] && command -v tput &>/dev/null && [[ $(tput colors 2>/dev/null || echo 0) -ge 8 ]]; then
+    GREEN=$(tput setaf 2)
+    RED=$(tput setaf 1)
+    BOLD=$(tput bold)
+    RESET=$(tput sgr0)
+else
+    GREEN=""
+    RED=""
+    BOLD=""
+    RESET=""
+fi
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+FAILED=0
+SERVICE="${1:-all}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+usage() {
+    echo "Usage: $0 [backend|frontend|all]"
+    exit 2
+}
+
+run_check() {
+    local label="$1"
+    shift
+    local cmd="$*"
+
+    printf "%s=> %s%s\n" "$BOLD" "$label" "$RESET"
+    printf "   %s\n" "$cmd"
+
+    if eval "$cmd"; then
+        printf "   %sPASS%s  %s\n\n" "$GREEN" "$RESET" "$label"
+    else
+        printf "   %sFAIL%s  %s\n\n" "$RED" "$RESET" "$label"
+        FAILED=1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Validate environment
+# ---------------------------------------------------------------------------
+# Find project root (directory containing both backend/ and frontend/)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../../" && pwd)"
+
+if [[ ! -d "$PROJECT_ROOT/backend" ]] || [[ ! -d "$PROJECT_ROOT/frontend" ]]; then
+    echo "${RED}Error:${RESET} Cannot find backend/ and frontend/ directories."
+    echo "Expected project root: $PROJECT_ROOT"
+    exit 2
+fi
+
+case "$SERVICE" in
+    backend|frontend|all) ;;
+    *) usage ;;
+esac
+
+echo "${BOLD}================================================================${RESET}"
+echo "${BOLD} rkgw verification — service: ${SERVICE}${RESET}"
+echo "${BOLD}================================================================${RESET}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Backend checks
+# ---------------------------------------------------------------------------
+if [[ "$SERVICE" == "backend" ]] || [[ "$SERVICE" == "all" ]]; then
+    echo "${BOLD}--- Backend ---${RESET}"
+    echo ""
+    run_check "cargo clippy (warnings as errors)" \
+        "cd '$PROJECT_ROOT/backend' && cargo clippy -- -D warnings"
+    run_check "cargo fmt (check formatting)" \
+        "cd '$PROJECT_ROOT/backend' && cargo fmt --check"
+    run_check "cargo test --lib (unit tests)" \
+        "cd '$PROJECT_ROOT/backend' && cargo test --lib"
+fi
+
+# ---------------------------------------------------------------------------
+# Frontend checks
+# ---------------------------------------------------------------------------
+if [[ "$SERVICE" == "frontend" ]] || [[ "$SERVICE" == "all" ]]; then
+    echo "${BOLD}--- Frontend ---${RESET}"
+    echo ""
+    run_check "npm run lint (eslint)" \
+        "cd '$PROJECT_ROOT/frontend' && npm run lint"
+    run_check "npm run build (tsc + vite)" \
+        "cd '$PROJECT_ROOT/frontend' && npm run build"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo "${BOLD}================================================================${RESET}"
+if [[ "$FAILED" -eq 0 ]]; then
+    echo "${GREEN}${BOLD}All checks passed.${RESET}"
+else
+    echo "${RED}${BOLD}One or more checks failed.${RESET}"
+fi
+echo "${BOLD}================================================================${RESET}"
+
+exit "$FAILED"

--- a/.claude/skills/conductor-manage/SKILL.md
+++ b/.claude/skills/conductor-manage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conductor-manage
-description: Manage track lifecycle — complete, archive, pause, resume, or delete tracks.
+description: Manage track lifecycle — complete, archive, pause, resume, or delete tracks. Use when user says 'complete track', 'archive track', 'pause work', 'resume track', 'delete track', or 'rename track'. Do NOT use for reverting git changes (use conductor-revert).
 argument-hint: "<track-id> [--action complete|archive|restore|pause|resume|rename|delete|cleanup]"
 allowed-tools:
   - Bash
@@ -14,6 +14,13 @@ allowed-tools:
 # Conductor Manage
 
 Manage the lifecycle of development tracks. Supports completing, archiving, restoring, pausing, resuming, renaming, deleting, and cleaning up tracks.
+
+## Critical Constraints
+
+- **Validate status transitions** — enforce the allowed-actions table (e.g., cannot complete a paused track without resuming first; cannot archive an in-progress track)
+- **Complete action requires all tasks checked** — verify all tasks are `[x]` or `[-]` in `plan.md` before allowing completion; warn if incomplete tasks remain
+- **Never use destructive git operations** — never delete git commits, force-push, or reset; track deletion removes conductor artifacts only, not git history
+- **Delete and rename require explicit confirmation** — always ask the user before executing these irreversible actions
 
 ---
 

--- a/.claude/skills/conductor-new-track/SKILL.md
+++ b/.claude/skills/conductor-new-track/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conductor-new-track
-description: Create a new development track with spec, phased plan, and metadata. Auto-detects affected rkgw services and suggests team preset.
+description: Create a new development track with spec, phased plan, and metadata. Auto-detects affected rkgw services and suggests team preset. Use when user says 'new feature', 'plan a bug fix', 'create a track', 'start a refactor', or 'I want to build X'.
 argument-hint: "<title> [--type feature|bug|refactor|chore]"
 allowed-tools:
   - Bash
@@ -15,6 +15,14 @@ allowed-tools:
 # Conductor New Track
 
 Create a new development track with a specification, phased implementation plan, and metadata. Automatically detects which rkgw services are affected and suggests the appropriate team preset.
+
+## Critical Constraints
+
+- **Ask ONE question per turn** — never batch multiple questions together; use AskUserQuestion for each, wait for the response, then proceed to the next
+- **Auto-detect services but always confirm with user** — present detected services and allow additions/removals before proceeding
+- **Check for duplicate/colliding track IDs** — scan `conductor/tracks.md` for similar titles and existing IDs; warn on fuzzy matches and handle ID collisions with numeric suffixes
+- **Never skip spec creation** — the spec review gate is mandatory; always present the generated spec to the user for approval before generating the plan
+- **Conductor must be initialized** — if `conductor/setup_state.json` does not exist or is incomplete, direct the user to run `conductor-setup` first and stop
 
 ---
 

--- a/.claude/skills/conductor-revert/SKILL.md
+++ b/.claude/skills/conductor-revert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conductor-revert
-description: Git-aware undo for track changes. Reverts tasks, phases, or entire tracks safely.
+description: Git-aware undo for track changes. Reverts tasks, phases, or entire tracks safely. Use when user says 'undo task changes', 'revert phase', 'roll back track', or 'preview revert'. Do NOT use for pausing, archiving, or completing tracks (use conductor-manage).
 argument-hint: "<track-id> [--task N.M] [--phase N] [--preview]"
 allowed-tools:
   - Bash
@@ -14,6 +14,14 @@ allowed-tools:
 # Conductor Revert
 
 Safely revert code changes made during track implementation. Uses `git revert` (never `git reset --hard`) to preserve history.
+
+## Critical Constraints
+
+- **Always use `git revert --no-edit`** — never use `git reset --hard`, `git push --force`, or any other destructive git operation
+- **Preserve git history** — all reverts must create new commits that undo changes, never rewrite history
+- **Preview mode (`--preview`) must not make any changes** — only display what would be reverted without executing
+- **Ask for confirmation before executing reverts** — always confirm with the user before running any `git revert` commands
+- **Never force-resolve conflicts** — if a revert causes a merge conflict, report it and ask the user to resolve, abort, or skip
 
 ---
 

--- a/.claude/skills/conductor-setup/SKILL.md
+++ b/.claude/skills/conductor-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conductor-setup
-description: Initialize or update conductor project artifacts.
+description: Initialize or update conductor project artifacts. Use when user says 'set up conductor', 'initialize project', 'add a new service', 'refresh tech stack', or 'first time setup'. Do NOT use for creating tracks (use conductor-new-track).
 argument-hint: "[--refresh] [--add-service name] [--resume]"
 allowed-tools:
   - Bash
@@ -15,6 +15,13 @@ allowed-tools:
 # Conductor Setup
 
 Initialize or update the conductor orchestration layer for the rkgw Gateway project.
+
+## Critical Constraints
+
+- **Ask ONE question per turn** — never batch multiple questions together; use AskUserQuestion and wait for the response before asking the next
+- **Never overwrite existing artifacts without confirmation** — if `conductor/` already exists during Full Init, ask before overwriting or switch to Refresh mode
+- **Resume from setup_state.json if it exists** — check `conductor/setup_state.json` first and continue from where a previous setup left off
+- **Never delete existing track data** — no mode (init, refresh, add-service) should remove track information
 
 ## Modes
 

--- a/.claude/skills/conductor-status/SKILL.md
+++ b/.claude/skills/conductor-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conductor-status
-description: Display project status — active tracks, progress, and active teams.
+description: Display project status — active tracks, progress, and active teams. Use when user says 'show progress', 'what is the status', 'how far along', 'list active tracks', or 'project overview'. Do NOT use for checking individual agent status (use team-status).
 argument-hint: "[track-id] [--tracks] [--teams] [--full]"
 allowed-tools:
   - Bash
@@ -12,6 +12,11 @@ allowed-tools:
 # Conductor Status
 
 Display the current status of the rkgw Gateway conductor orchestration layer. Shows active tracks, implementation progress, and active agent teams.
+
+## Critical Constraints
+
+- **Read-only** — this skill never modifies any files; it only reads and displays information
+- **Fail gracefully if conductor/ directory doesn't exist** — if conductor is not initialized, suggest running `conductor-setup` instead of erroring out
 
 ---
 

--- a/.claude/skills/team-coordination/SKILL.md
+++ b/.claude/skills/team-coordination/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-coordination
-description: Reference guide for team composition patterns, file ownership rules, communication protocols, task coordination, and parallel development strategies.
+description: Reference guide for team composition patterns, file ownership rules, communication protocols, task coordination, and parallel development strategies. Use when user asks about 'file ownership rules', 'team communication', 'how to coordinate agents', or 'team sizing'.
 ---
 
 # Team Coordination Reference

--- a/.claude/skills/team-debug/SKILL.md
+++ b/.claude/skills/team-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-debug
-description: ACH-based debugging — spawns domain investigators to evaluate competing hypotheses across the rkgw stack using formal evidence standards and arbitration.
+description: ACH-based debugging — spawns domain investigators to evaluate competing hypotheses across the rkgw stack using formal evidence standards and arbitration. Use when user says 'debug this error', 'why is this failing', 'investigate bug', 'root cause analysis', or 'something is broken'.
 argument-hint: "[error-description] [--scope path] [--hypotheses count]"
 allowed-tools:
   - Bash
@@ -17,6 +17,13 @@ allowed-tools:
 Structured debugging methodology that spawns multiple AI investigators to evaluate competing hypotheses in parallel. Based on the ACH (Analysis of Competing Hypotheses) framework, adapted for the rkgw Gateway stack.
 
 See `references/hypothesis-testing.md` for templates, decision trees, and rkgw-specific examples.
+
+## Critical Constraints
+
+- **Agent teams required** — `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` must be set
+- **Read-only investigators** — investigators must not modify code; their sole job is to collect evidence and report verdicts
+- **Formal evidence standards** — all evidence must be classified by type (Direct, Correlational, Testimonial, Absence) with file:line citations
+- **Report only** — never auto-fix the root cause; present findings, causal chain, and suggested fix in the debug report
 
 ---
 

--- a/.claude/skills/team-delegate/SKILL.md
+++ b/.claude/skills/team-delegate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-delegate
-description: Assign tasks, send messages, and manage workload across team members.
+description: Assign tasks, send messages, and manage workload across team members. Use when user says 'assign task to agent', 'send message to team', 'rebalance workload', or 'broadcast to team'. Do NOT use for full feature orchestration (use team-feature).
 argument-hint: "[team-name] [--assign agent 'task'] [--message agent 'content']"
 allowed-tools:
   - Bash
@@ -14,6 +14,12 @@ allowed-tools:
 
 Assign tasks, send messages, and manage workload across rkgw Gateway team members.
 
+## Critical Constraints
+
+- **Team must exist** — verify `~/.claude/teams/{team-name}/config.json` exists before delegating; fail if team config is missing
+- **Use SendMessage** — all inter-agent communication must go through `SendMessage`, not file-based coordination
+- **Respect file ownership** — never assign files that are owned by another agent; check existing assignments before delegating
+
 ---
 
 ## Step 1: Load Team
@@ -24,6 +30,8 @@ ls -1 ~/.claude/teams/ 2>/dev/null
 ```
 
 Load `~/.claude/teams/{team-name}/config.json`.
+
+> **If the team config is not found at the expected path:** List all available teams from `~/.claude/teams/` and present them to the user. If no team directories exist at all, report "No active teams found. Use /team-spawn to create a team first." and stop.
 
 ## Step 2: Determine Mode
 
@@ -52,7 +60,11 @@ Actions:
 ### Assign Task
 Validate agent is one of: scrum-master, rust-backend-engineer, react-frontend-engineer, devops-engineer, backend-qa, frontend-qa, document-writer.
 
+> **If the specified agent is not found in the team:** List the available team members from the loaded config (names and roles) and ask the user to pick a valid agent from the list.
+
 Send via `SendMessage` with task description, priority, and context.
+
+> **If SendMessage delivery fails:** Retry the message once. If it still fails, report the error to the user (including the target agent name and error details) and suggest checking whether the agent process is still running.
 
 ### Send Message
 Direct message via `SendMessage`.
@@ -62,6 +74,8 @@ Send to ALL agents with `type: "broadcast"`.
 
 ### Rebalance
 Review assignments, identify idle/overloaded/blocked agents, suggest reassignments.
+
+> **If no idle agents are available for rebalancing:** Report the current workload distribution for all agents (agent name, current task, how long they have been working) and suggest the user either wait for an agent to finish or manually reassign a lower-priority task.
 
 ## Step 4: Update Config
 

--- a/.claude/skills/team-feature/SKILL.md
+++ b/.claude/skills/team-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-feature
-description: Coordinated parallel feature development with automated team spawning, task decomposition, and integration verification. Dynamically adapts to any project stack via conductor context.
+description: Coordinated parallel feature development with automated team spawning, task decomposition, and integration verification. Dynamically adapts to any project stack via conductor context. Use when user says 'build this feature end to end', 'coordinate frontend and backend', or 'full feature development'. Do NOT use for executing tasks from an existing track plan (use conductor-implement).
 argument-hint: "[feature-description] [--preset name] [--plan-first]"
 allowed-tools:
   - Bash
@@ -16,6 +16,13 @@ allowed-tools:
 
 Coordinated parallel feature development. All service detection, agent mapping, and verification commands are loaded dynamically from project configuration.
 
+## Critical Constraints
+
+- **Agent teams required** — `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` must be set
+- **Dynamic service detection** — load service categories, agent mappings, and verification commands from conductor context (`conductor/tech-stack.md` and `.claude/agents/*.md`); never hardcode service names or agent roles
+- **One owner per file** — no file may be assigned to multiple agents
+- **Cross-service contract verification** — verify that both sides of every interface contract are implemented before reporting success
+
 ---
 
 ## Step 1: Load Project Context
@@ -30,6 +37,8 @@ Read project configuration to build service detection and verification maps:
 2. **Read `.claude/agents/*.md`** frontmatter to build agent registry:
    - Map each agent's description keywords to the service categories from tech-stack.md
    - Result: a `service-to-agent` map (e.g., Backend -> agent whose description matches backend technologies)
+
+   > **If no matching agent is found for a detected service:** Warn the user (e.g., "No agent definition matches the '{service}' service. You can manually assign an agent or spawn a general-purpose agent for this service.") and suggest manual assignment. Continue building the map for the remaining services.
 
 3. **Build keyword detection table** from tech-stack.md. For each service category, extract:
    - Technology names (e.g., "Axum", "React", "nginx")
@@ -53,6 +62,8 @@ For each service category from tech-stack.md:
 - Determine which services are affected
 
 Map affected services to agents using the service-to-agent map from Step 1.
+
+> **If no services are detected from the feature description:** Ask the user to specify which services are involved (e.g., "I couldn't detect which services this feature affects. Please specify: Backend, Frontend, Infrastructure, or a combination."). Do not proceed with team spawning until at least one service is confirmed.
 
 Also detect if testing agents are needed:
 - Look for test-related keywords in the feature description
@@ -107,6 +118,8 @@ Wave execution:
 - Start Wave 3 agents after feature code is substantially complete
 - Start Wave 4 agents after implementation is stable
 
+> **If an agent fails mid-task during work stream execution:** Report the failure to the user, including the agent name, error output, and which work stream was affected. Collect any partial results the agent produced (files created/modified, tests written). Then ask the user how to proceed: retry the failed agent, reassign the work stream to another agent, or continue with the remaining work streams and address the gap manually.
+
 ## Step 7: Integration Verification
 
 Run verification commands dynamically based on the verification command map built in Step 1.
@@ -119,6 +132,8 @@ For each service in affected_services:
 ```
 
 If no commands were found in tech-stack.md for a service, skip verification for that service and note it in the report.
+
+> **If verification commands fail (non-zero exit from lint, build, or test):** Report which specific checks failed, include the command output (stderr/stdout), and ask the user whether to fix the issues before completing or proceed despite the failures. Do not mark the feature as COMPLETE if any verification check has failed — use status NEEDS_ATTENTION in the final report.
 
 ### Cross-Service Contract Validation
 

--- a/.claude/skills/team-review/SKILL.md
+++ b/.claude/skills/team-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-review
-description: "Launch a multi-reviewer parallel code review organized by quality dimensions (Security, Performance, Architecture, Testing, Accessibility)"
+description: Launch a multi-reviewer parallel code review organized by quality dimensions (Security, Performance, Architecture, Testing, Accessibility). Use when user says 'review this code', 'security review', 'review my PR', 'code quality check', or 'architecture review'.
 argument-hint: "<target> [--reviewers security,performance,architecture,testing,accessibility] [--base-branch main]"
 allowed-tools:
   - Bash
@@ -17,6 +17,13 @@ allowed-tools:
 Orchestrate a multi-reviewer parallel code review where each reviewer focuses on a specific quality dimension. Produces a consolidated, deduplicated report organized by severity.
 
 Refer to `references/review-dimensions.md` for detailed per-dimension checklists.
+
+## Critical Constraints
+
+- **Agent teams required** — `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` must be set
+- **Report only** — never auto-fix findings; reviewers report issues but do not modify code
+- **Deduplicate findings** — merge identical findings across reviewers (same file:line, same issue) into a single entry crediting all dimensions
+- **Clean up after completion** — shut down all reviewer agents after the consolidated report is produced
 
 ---
 

--- a/.claude/skills/team-review/references/run-checks.sh
+++ b/.claude/skills/team-review/references/run-checks.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# run-checks.sh — Run all lint/test/build checks and output a summary.
+#
+# Runs every check regardless of individual failures, then prints a summary
+# table with pass/fail counts.
+#
+# Usage:
+#   ./run-checks.sh
+#
+# Exit codes:
+#   0 — All checks passed
+#   1 — One or more checks failed
+#   2 — Missing project directory
+
+# Do NOT use "set -e" — we intentionally continue past failures.
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Color support
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]] && command -v tput &>/dev/null && [[ $(tput colors 2>/dev/null || echo 0) -ge 8 ]]; then
+    GREEN=$(tput setaf 2)
+    RED=$(tput setaf 1)
+    BOLD=$(tput bold)
+    RESET=$(tput sgr0)
+else
+    GREEN=""
+    RED=""
+    BOLD=""
+    RESET=""
+fi
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+declare -a CHECK_NAMES=()
+declare -a CHECK_RESULTS=()
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+run_check() {
+    local label="$1"
+    shift
+    local cmd="$*"
+
+    printf "%s=> %s%s\n" "$BOLD" "$label" "$RESET"
+    printf "   %s\n" "$cmd"
+
+    if eval "$cmd"; then
+        CHECK_NAMES+=("$label")
+        CHECK_RESULTS+=("PASS")
+        PASS_COUNT=$((PASS_COUNT + 1))
+        printf "   %sPASS%s  %s\n\n" "$GREEN" "$RESET" "$label"
+    else
+        CHECK_NAMES+=("$label")
+        CHECK_RESULTS+=("FAIL")
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        printf "   %sFAIL%s  %s\n\n" "$RED" "$RESET" "$label"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Validate environment
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../../" && pwd)"
+
+if [[ ! -d "$PROJECT_ROOT/backend" ]] || [[ ! -d "$PROJECT_ROOT/frontend" ]]; then
+    echo "${RED}Error:${RESET} Cannot find backend/ and frontend/ directories."
+    echo "Expected project root: $PROJECT_ROOT"
+    exit 2
+fi
+
+echo "${BOLD}================================================================${RESET}"
+echo "${BOLD} rkgw quality checks${RESET}"
+echo "${BOLD}================================================================${RESET}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Backend checks
+# ---------------------------------------------------------------------------
+echo "${BOLD}--- Backend ---${RESET}"
+echo ""
+
+run_check "cargo clippy (warnings as errors)" \
+    "cd '$PROJECT_ROOT/backend' && cargo clippy -- -D warnings"
+
+run_check "cargo fmt (check formatting)" \
+    "cd '$PROJECT_ROOT/backend' && cargo fmt --check"
+
+run_check "cargo test --lib (unit tests)" \
+    "cd '$PROJECT_ROOT/backend' && cargo test --lib"
+
+# ---------------------------------------------------------------------------
+# Frontend checks
+# ---------------------------------------------------------------------------
+echo "${BOLD}--- Frontend ---${RESET}"
+echo ""
+
+run_check "npm run lint (eslint)" \
+    "cd '$PROJECT_ROOT/frontend' && npm run lint"
+
+run_check "npm run build (tsc + vite)" \
+    "cd '$PROJECT_ROOT/frontend' && npm run build"
+
+# ---------------------------------------------------------------------------
+# Summary table
+# ---------------------------------------------------------------------------
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+
+echo "${BOLD}================================================================${RESET}"
+echo "${BOLD} Summary${RESET}"
+echo "${BOLD}================================================================${RESET}"
+printf "%-45s %s\n" "Check" "Result"
+printf "%-45s %s\n" "---------------------------------------------" "------"
+
+for i in "${!CHECK_NAMES[@]}"; do
+    result="${CHECK_RESULTS[$i]}"
+    if [[ "$result" == "PASS" ]]; then
+        color="$GREEN"
+    else
+        color="$RED"
+    fi
+    printf "%-45s %s%s%s\n" "${CHECK_NAMES[$i]}" "$color" "$result" "$RESET"
+done
+
+echo ""
+printf "Total: %d   ${GREEN}Passed: %d${RESET}   ${RED}Failed: %d${RESET}\n" \
+    "$TOTAL" "$PASS_COUNT" "$FAIL_COUNT"
+echo "${BOLD}================================================================${RESET}"
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    echo "${RED}${BOLD}Some checks failed.${RESET}"
+    exit 1
+else
+    echo "${GREEN}${BOLD}All checks passed.${RESET}"
+    exit 0
+fi

--- a/.claude/skills/team-shutdown/SKILL.md
+++ b/.claude/skills/team-shutdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-shutdown
-description: Gracefully terminate an agent team and clean up its configuration.
+description: Gracefully terminate an agent team and clean up its configuration. Use when user says 'shut down team', 'stop all agents', 'clean up team', 'terminate agents', or 'kill the team'.
 argument-hint: "[team-name] [--force] [--keep-config]"
 allowed-tools:
   - Bash
@@ -12,6 +12,12 @@ allowed-tools:
 # Team Shutdown
 
 Gracefully terminate an agent team and clean up its configuration.
+
+## Critical Constraints
+
+- **Ordered shutdown** — terminate worker agents (engineers, QA, document-writer) first, scrum-master last
+- **Confirm before proceeding** — show team status and ask for user confirmation unless `--force` is provided
+- **Clean up team config** — remove `~/.claude/teams/{team-name}/` and `~/.claude/tasks/{team-name}/` after shutdown (unless `--keep-config`)
 
 ---
 

--- a/.claude/skills/team-spawn/SKILL.md
+++ b/.claude/skills/team-spawn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-spawn
-description: Initialize agent teams from presets or custom composition. Dynamically loads agent definitions and service mappings from project configuration.
+description: Initialize agent teams from presets or custom composition. Dynamically loads agent definitions and service mappings from project configuration. Use when user says 'spin up a team', 'create agents', 'need a fullstack team', 'start backend team', or 'spawn agents'.
 argument-hint: "[preset] [--delegate]"
 allowed-tools:
   - Bash
@@ -14,6 +14,13 @@ allowed-tools:
 
 Initialize agent teams from presets or custom composition. Agent definitions and service mappings are loaded dynamically from project configuration — no hardcoded agent names or colors.
 
+## Critical Constraints
+
+- **Agent teams required** — `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` must be set
+- **Dynamic agent loading** — load agent definitions from `.claude/agents/*.md` at runtime; never hardcode agent names, roles, or colors
+- **Background spawning** — spawn all agents with `run_in_background: true`
+- **Persist team config** — save team config to `~/.claude/teams/{team-name}/config.json` after spawning
+
 ---
 
 ## Step 1: Load Project Context
@@ -24,6 +31,8 @@ Read the following files to build the agent registry and service map:
    - `name` — agent identifier
    - `description` — role summary (first sentence is the short role)
    - `model` — model override (if any)
+
+   > **If an agent .md file is not found or its YAML frontmatter cannot be parsed:** Skip that agent, warn the user (e.g., "Skipping agent '{filename}': unable to parse definition"), and continue loading the remaining agent files. The team can still be spawned with the successfully loaded agents.
 
 2. **Tech stack** — Read `conductor/tech-stack.md` to identify:
    - Service categories (e.g., Backend, Frontend, Infrastructure)
@@ -69,6 +78,8 @@ Presets reference agents by **role keywords**, not hardcoded names. Match each r
 - "documentation" — agent whose description contains "documentation", "docs", or "writing"
 
 ### Custom Composition
+
+> **If the preset name is not recognized:** List all available presets (from the table above) and the available agents from the registry, then ask the user to choose a valid preset or specify agents by name.
 
 If no preset matches, or user specifies agent names directly, use those. If no preset or agent list is provided, prompt:
 
@@ -131,6 +142,8 @@ Format: `{preset-or-custom}-{short-id}` (4 random alphanumeric chars).
 cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c4
 ```
 
+> **If the generated team name collides with an existing team** (i.e., `~/.claude/teams/{team-name}/` already exists): Append a random 4-character suffix and retry. If the collision persists after 3 attempts, prompt the user for a custom team name.
+
 ## Step 4: Spawn Agents
 
 For each agent in the resolved composition, spawn using the registry data:
@@ -153,6 +166,8 @@ For generic presets (research, security, migration) where agents are not from de
 - migration: `agent-teams:team-lead`, `agent-teams:team-implementer`, `agent-teams:team-reviewer`
 
 Run each spawn command with `run_in_background: true`.
+
+> **If an agent spawn command fails (non-zero exit):** Retry the spawn once. If it still fails, report the error (including the agent name and exit code), mark that agent as `"status": "failed"` in the team config, and continue spawning the remaining agents. Do not abort the entire team spawn due to a single agent failure.
 
 ## Step 5: Register Team
 

--- a/.claude/skills/team-status/SKILL.md
+++ b/.claude/skills/team-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-status
-description: Monitor agent team members, their roles, and current task status.
+description: Monitor agent team members, their roles, and current task status. Use when user says 'how are agents doing', 'who is idle', 'team progress', 'check agent status', or 'show team members'. Do NOT use for project track progress (use conductor-status).
 argument-hint: "[team-name] [--tasks] [--members] [--json]"
 allowed-tools:
   - Bash
@@ -10,6 +10,11 @@ allowed-tools:
 # Team Status
 
 Monitor agent team members, their roles, and current task status for rkgw Gateway teams.
+
+## Critical Constraints
+
+- **Read-only** — never modify team config, task state, or any project files; this skill is strictly observational
+- **Graceful degradation** — if team config is missing or malformed, report the absence clearly instead of failing
 
 ---
 
@@ -25,6 +30,8 @@ Monitor agent team members, their roles, and current task status for rkgw Gatewa
 cat ~/.claude/teams/{team-name}/config.json
 ```
 
+> **If the config file is missing or cannot be read:** Check whether any team configs exist at all by listing `~/.claude/teams/`. If other teams are found, list them and ask the user to specify the correct team name. If no team directories exist, report "No active teams found. Use /team-spawn to create a team first." and stop.
+
 Also check conductor tracks:
 ```bash
 cat /Users/hikennoace/ai-gateway/rkgw/conductor/tracks.md 2>/dev/null
@@ -36,9 +43,13 @@ cat /Users/hikennoace/ai-gateway/rkgw/conductor/tracks.md 2>/dev/null
 ps aux | grep "claude.*--team-name {team-name}" | grep -v grep
 ```
 
+> **If the `ps` command fails to find agent processes** (returns no matches or errors): Mark those agents as "status unknown" in the report rather than "stopped". An absent process entry may mean the agent exited, was never started, or the process name pattern does not match -- do not assume the agent has stopped.
+
 ## Step 4: Compile Task Status
 
 Gather from TaskList and team config.
+
+> **If TaskList returns empty or no tasks are found:** Report "No active tasks" in the Tasks section of the output rather than failing or omitting the section. This is a normal state for newly spawned teams or teams between assignments.
 
 ## Step 5: Output Report
 

--- a/.claude/skills/track-management/SKILL.md
+++ b/.claude/skills/track-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: track-management
-description: Reference guide for creating, managing, and completing Conductor tracks — the logical work units for features, bugs, and refactors.
+description: Reference guide for creating, managing, and completing Conductor tracks — the logical work units for features, bugs, and refactors. Use when user asks 'how do tracks work', 'track lifecycle', 'what status markers mean', or 'track sizing guidelines'. Do NOT use to take action on tracks (use conductor-manage).
 ---
 
 # Track Management Reference

--- a/.claude/skills/workflow-patterns/SKILL.md
+++ b/.claude/skills/workflow-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-patterns
-description: Reference guide for implementing tasks according to Conductor's TDD workflow, handling phase checkpoints, managing git commits, and understanding the verification protocol.
+description: Reference guide for implementing tasks according to Conductor's TDD workflow, handling phase checkpoints, managing git commits, and understanding the verification protocol. Use when user asks about 'TDD policy', 'phase checkpoints', 'git commit format', 'quality gates', or 'task lifecycle'.
 ---
 
 # Workflow Patterns Reference


### PR DESCRIPTION
## Summary

- **P0 — Trigger phrases**: All 16 skill descriptions now include "Use when user says..." trigger phrases and 8 overlapping skills have "Do NOT use for..." negative triggers for disambiguation
- **P1 — Critical Constraints**: Added `## Critical Constraints` sections at the top of all 13 actionable skills, surfacing buried rules (never auto-commit, phase gates, branch requirements, etc.)
- **P1 — Error handling**: Added inline error recovery at failure-prone steps in 4 team skills (team-spawn, team-feature, team-delegate, team-status)
- **P1 — Validation scripts**: Created `verify.sh` and `run-checks.sh` for deterministic quality checks (cargo clippy/fmt/test, npm lint/build)
- **P2 — Backend rules**: New `rules/backend.md` with Rust coding standards (mirrors existing `rules/web-ui.md`)
- **P2 — Doc fixes**: Fixed stale agent count (7→8), fixed team-review YAML quoting inconsistency

## Test plan

- [ ] Verify skill triggering: ask Claude "When would you use conductor-status?" — should quote trigger phrases
- [ ] Verify disambiguation: ask "Should I use conductor-status or team-status?" — should explain the difference
- [ ] Verify validation scripts: `bash .claude/skills/conductor-implement/references/verify.sh backend`
- [ ] Verify no regressions in skill invocation via `/conductor-status`, `/team-spawn`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)