### PR TITLE
chore: set all agent models to opus

### DIFF
--- a/.claude/agents/backend-qa.md
+++ b/.claude/agents/backend-qa.md
@@ -2,7 +2,7 @@
 name: backend-qa
 description: Rust unit and integration test specialist. Use for writing and running backend tests, verifying endpoint behavior, testing converters, streaming parsers, auth flows, middleware chains, and guardrails logic. Expert in cargo test, tokio::test, and the project's test infrastructure.
 tools: Read, Write, Edit, Bash, Grep, Glob
-model: inherit
+model: opus
 memory: project
 ---
 

--- a/.claude/agents/conductor-validator.md
+++ b/.claude/agents/conductor-validator.md
@@ -2,7 +2,7 @@
 name: conductor-validator
 description: Conductor artifact validation specialist. Use for auditing conductor directory structure, verifying track consistency, checking content completeness, and validating state files. Read-only — never modifies files. Reports findings at CRITICAL, WARNING, and INFO severity levels.
 tools: Read, Glob, Grep, Bash
-model: inherit
+model: opus
 memory: project
 ---
 

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -2,7 +2,7 @@
 name: devops-engineer
 description: Docker, nginx, deployment, and infrastructure specialist. Use for managing Docker Compose services, nginx configuration, TLS certificates, deployment modes, environment variables, health checks, and monitoring setup.
 tools: Read, Edit, Write, Bash, Grep, Glob
-model: inherit
+model: opus
 memory: project
 ---
 

--- a/.claude/agents/document-writer.md
+++ b/.claude/agents/document-writer.md
@@ -2,7 +2,7 @@
 name: document-writer
 description: Documentation and communication specialist. Use for writing API docs, architecture guides, deployment runbooks, release notes, publishing to Notion, and communicating via Slack. Covers both backend (Rust/Axum) and frontend (React 19) documentation.
 tools: Read, Write, Edit, Bash, Grep, Glob
-model: inherit
+model: opus
 memory: project
 ---
 

--- a/.claude/agents/frontend-qa.md
+++ b/.claude/agents/frontend-qa.md
@@ -2,7 +2,7 @@
 name: frontend-qa
 description: Web QA and E2E test specialist. Use for writing and running browser-based tests on the rkgw Web UI using Playwright. Tests dashboard metrics, configuration management, admin workflows, Google SSO login, and all UI interactions.
 tools: Read, Edit, Write, Bash, Grep, Glob
-model: inherit
+model: opus
 memory: project
 ---
 

--- a/.claude/agents/react-frontend-engineer.md
+++ b/.claude/agents/react-frontend-engineer.md
@@ -2,7 +2,7 @@
 name: react-frontend-engineer
 description: React frontend implementation specialist. Use for implementing Web UI pages, components, API integrations, SSE streaming, and frontend bug fixes. Follows the project's minimalist architecture with React 19, TypeScript 5.9, Vite 7, and CRT terminal aesthetic.
 tools: Read, Edit, Write, Bash, Grep, Glob
-model: inherit
+model: opus
 memory: project
 ---
 

--- a/.claude/agents/rust-backend-engineer.md
+++ b/.claude/agents/rust-backend-engineer.md
@@ -2,7 +2,7 @@
 name: rust-backend-engineer
 description: Rust/Axum backend implementation specialist. Use for implementing API endpoints, format converters, streaming parsers, authentication flows, guardrails engine, MCP client orchestration, middleware, and backend bug fixes. Follows the project's async architecture with Axum 0.7, Tokio, sqlx, and tracing.
 tools: Read, Edit, Write, Bash, Grep, Glob
-model: inherit
+model: opus
 memory: project
 ---
 


### PR DESCRIPTION
## Summary
- Changed `model: inherit` to `model: opus` on all 7 remaining agent definitions (scrum-master already had `opus`)
- Ensures all subagents explicitly use Opus rather than inheriting the parent session's model

## Test plan
- [ ] Verify agent spawning works with explicit `model: opus` setting
- [ ] Confirm no regressions in team workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)