### PR TITLE
feat: update gh-pages CRT styling and refresh documentation

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -4,6 +4,7 @@
 | ------ | -------- | ----- | ------- | ------- |
 | completed | copilot-provider-support_20260308 | Add GitHub Copilot Provider Support | 2026-03-08 | 2026-03-08 |
 | completed | qwen-coder-provider_20260308 | Add Qwen Coder Provider Support | 2026-03-08 | 2026-03-08 |
+| completed | ghpages-crt-styling_20260308 | Update GH-Pages Styling and Content to Match Frontend CRT Aesthetic | 2026-03-08 | 2026-03-08 |
 
 <!-- Tracks registered by /conductor:new-track -->
 

--- a/conductor/tracks/ghpages-crt-styling_20260308/index.md
+++ b/conductor/tracks/ghpages-crt-styling_20260308/index.md
@@ -1,0 +1,23 @@
+# Track: Update GH-Pages Styling and Content to Match Frontend CRT Aesthetic
+
+**ID:** ghpages-crt-styling_20260308
+**Type:** feature
+**Status:** draft
+
+## Documents
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+
+## Progress
+- Phases: 0/4 complete (Wave 1: 3 parallel, Wave 2: QA)
+- Tasks: 0/18 complete
+
+## Team (3 parallel react-frontend-engineers)
+- **fe-styling**: SCSS, CRT effects, index.md (6 tasks)
+- **fe-docs-arch**: Architecture docs, modules, mermaid diagrams (4 tasks)
+- **fe-docs-ops**: API reference, config, deployment, user-facing docs (5 tasks)
+- **frontend-qa**: Visual verification after Wave 1 (3 tasks)
+
+## Quick Links
+- [Back to Tracks](../../tracks.md)
+- [Product Context](../../product.md)

--- a/conductor/tracks/ghpages-crt-styling_20260308/metadata.json
+++ b/conductor/tracks/ghpages-crt-styling_20260308/metadata.json
@@ -1,0 +1,24 @@
+{
+  "id": "ghpages-crt-styling_20260308",
+  "title": "Update GH-Pages Styling and Content to Match Frontend CRT Aesthetic",
+  "type": "feature",
+  "status": "completed",
+  "preset": "frontend-feature",
+  "services": ["docs"],
+  "agents": ["scrum-master", "react-frontend-engineer", "react-frontend-engineer", "react-frontend-engineer", "frontend-qa"],
+  "agent_roles": {
+    "fe-styling": "react-frontend-engineer — SCSS styling, CRT effects, index.md",
+    "fe-docs-arch": "react-frontend-engineer — architecture docs, modules, mermaid diagrams",
+    "fe-docs-ops": "react-frontend-engineer — API reference, config, deployment, user-facing docs"
+  },
+  "branch": "feat/ghpages-crt-styling",
+  "created": "2026-03-08T13:30:00.000Z",
+  "updated": "2026-03-08T14:03:00.000Z",
+  "phases": {
+    "1": { "name": "Wave 1: CRT Styling (fe-styling)", "status": "completed", "tasks_total": 6, "tasks_done": 6 },
+    "2": { "name": "Wave 1: Architecture Docs (fe-docs-arch)", "status": "completed", "tasks_total": 4, "tasks_done": 4 },
+    "3": { "name": "Wave 1: Ops & User Docs (fe-docs-ops)", "status": "completed", "tasks_total": 5, "tasks_done": 5 },
+    "4": { "name": "Wave 2: Visual QA (frontend-qa)", "status": "completed", "tasks_total": 3, "tasks_done": 3 }
+  },
+  "commits": []
+}

--- a/conductor/tracks/ghpages-crt-styling_20260308/plan.md
+++ b/conductor/tracks/ghpages-crt-styling_20260308/plan.md
@@ -1,0 +1,43 @@
+# ghpages-crt-styling_20260308: Implementation Plan
+
+**Status**: draft
+**Branch**: feat/ghpages-crt-styling
+**Parallelism**: 3 react-frontend-engineers + 1 frontend-qa
+
+## Wave 1 (Parallel — all 3 agents start simultaneously)
+
+### Agent: fe-styling (react-frontend-engineer)
+**File ownership**: `_sass/custom/custom.scss`, `index.md`
+
+- [ ] 1.1 — Rewrite `_sass/custom/custom.scss` color palette: replace teal/blue/amber with frontend's green (#4ade80), cyan (#22d3ee), red (#f87171), yellow (#fbbf24), blue (#60a5fa). Dark backgrounds (#060609, #0b0b10, #101018), borders (#1a1a26), text (#b8ccb8, #7a8e7a)
+- [ ] 1.2 — Add JetBrains Mono font import and apply as primary font throughout. Set line-height 1.5, font weights 400/500/600/700
+- [ ] 1.3 — Add CRT effects: scanline overlay (::before pseudo-element, 2-4px repeating gradient), vignette (radial gradient edge darkening), dot grid pattern, phosphor glow on headings/links/code (box-shadow with rgba(74,222,128))
+- [ ] 1.4 — Update component patterns: sharp borders (2-3px radius), left-border accents on feature/nav cards, uppercase labels with letter-spacing, hover glow instead of lift
+- [ ] 1.5 — Style code blocks, tables, blockquotes, and inline code to match frontend patterns (green-tinted backgrounds, sharp corners, monospace)
+- [ ] 1.6 — Update `index.md`: hero section styling (gradient text white→green), feature cards, nav cards to CRT style, AND update content to reflect current features (multi-provider, guardrails, MCP gateway, Qwen/Copilot providers)
+
+### Agent: fe-docs-arch (react-frontend-engineer)
+**File ownership**: `docs/architecture/index.md`, `docs/architecture/request-flow.md`, `docs/architecture/authentication.md`, `docs/architecture/converters.md`, `docs/architecture/streaming.md`, `docs/modules.md`
+
+- [ ] 2.1 — Update `docs/architecture/index.md` and `docs/architecture/request-flow.md`: update mermaid diagrams for current request flow including provider routing, guardrails, MCP
+- [ ] 2.2 — Update `docs/architecture/authentication.md`: add multi-provider OAuth (Copilot, Qwen device flow), per-user Kiro token management, update mermaid diagrams
+- [ ] 2.3 — Update `docs/architecture/converters.md` and `docs/architecture/streaming.md`: reflect current converter architecture and streaming parser
+- [ ] 2.4 — Update `docs/modules.md`: add guardrails/, mcp/, providers/ modules, update existing module descriptions
+
+### Agent: fe-docs-ops (react-frontend-engineer)
+**File ownership**: `docs/api-reference.md`, `docs/web-ui.md`, `docs/configuration.md`, `docs/deployment.md`, `docs/getting-started.md`, `docs/quickstart.md`, `docs/client-setup.md`, `docs/troubleshooting.md`, `docs/research-notes.md`
+
+- [ ] 3.1 — Update `docs/api-reference.md`: add MCP endpoints, guardrails endpoints, provider OAuth endpoints
+- [ ] 3.2 — Update `docs/web-ui.md`: reflect current admin pages (MCP clients, guardrails, provider management, user management)
+- [ ] 3.3 — Update `docs/configuration.md` and `docs/deployment.md`: add proxy-only mode, provider env vars, guardrails/MCP config
+- [ ] 3.4 — Update `docs/getting-started.md`, `docs/quickstart.md`, `docs/client-setup.md`: reflect current setup flow and multi-provider support
+- [ ] 3.5 — Update `docs/troubleshooting.md` and `docs/research-notes.md`: add provider-specific troubleshooting, update research notes
+
+## Wave 2 (After Wave 1 completes)
+
+### Agent: frontend-qa
+**File ownership**: read-only (screenshots to `.playwright-mcp/`)
+
+- [ ] 4.1 — Visual verification: screenshot all pages, verify CRT aesthetic consistency across index, docs, architecture subpages
+- [ ] 4.2 — Verify responsive behavior at 800px and 500px breakpoints
+- [ ] 4.3 — Verify mermaid diagrams render correctly with new color scheme

--- a/conductor/tracks/ghpages-crt-styling_20260308/spec.md
+++ b/conductor/tracks/ghpages-crt-styling_20260308/spec.md
@@ -1,0 +1,27 @@
+# ghpages-crt-styling_20260308: Update GH-Pages Styling and Content to Match Frontend CRT Aesthetic
+
+**Type**: feature
+**Created**: 2026-03-08
+**Preset**: frontend-feature
+**Services**: docs
+
+## Problem Statement
+The gh-pages documentation site uses a teal/glass-morphism "infrastructure command center" aesthetic that is visually disconnected from the frontend web UI's CRT phosphor terminal theme. Additionally, the documentation content and mermaid diagrams are outdated and no longer reflect the current architecture (multi-provider support, guardrails, MCP gateway, Qwen/Copilot providers, etc.).
+
+## User Story
+As a developer visiting the docs site, I want the documentation to visually match the gateway's web UI so that the product feels cohesive and professionally branded.
+
+## Acceptance Criteria
+1. Color palette matches frontend variables.css — background (#060609), surfaces, borders, green (#4ade80), cyan (#22d3ee), red/yellow/blue accents
+2. Typography uses JetBrains Mono as primary font, monospace throughout, matching font weights and line-height
+3. CRT effects applied — scanline overlay, vignette/dot grid, phosphor glow on headings/links/code blocks
+4. Component patterns match frontend — sharp corners (2-3px radius), left-border accents on cards, uppercase labels with letter-spacing
+5. All documentation pages updated to reflect current project state (multi-provider, guardrails, MCP, Qwen/Copilot providers, etc.)
+6. All mermaid diagrams updated to match current architecture and request flows
+
+## Scope Boundaries
+**Out of scope:**
+- Frontend style modifications (read-only reference)
+
+## Dependencies
+None — frontend styles are stable and can be referenced directly.

--- a/gh-pages/_includes/head_custom.html
+++ b/gh-pages/_includes/head_custom.html
@@ -1,94 +1,95 @@
 <style>
 /* ============================================================
-   Kiro Gateway — Infrastructure Command Center Theme
+   Kiro Gateway — CRT Phosphor Terminal Theme
    ============================================================ */
 
 :root {
-  --kgw-teal: #00d4aa;
-  --kgw-teal-dim: #009e7e;
-  --kgw-teal-glow: rgba(0, 212, 170, 0.15);
-  --kgw-teal-border: rgba(0, 212, 170, 0.3);
-  --kgw-blue: #5b9df5;
-  --kgw-amber: #f5a623;
-  --kgw-indigo: #818cf8;
-  --kgw-gray: #8892a4;
-  --kgw-surface: rgba(255, 255, 255, 0.04);
-  --kgw-surface-hover: rgba(255, 255, 255, 0.07);
-  --kgw-border: rgba(255, 255, 255, 0.08);
-  --kgw-border-hover: rgba(0, 212, 170, 0.4);
+  --kgw-green: #4ade80;
+  --kgw-green-dim: #22c55e;
+  --kgw-green-glow: rgba(74, 222, 128, 0.15);
+  --kgw-green-border: rgba(74, 222, 128, 0.3);
+  --kgw-cyan: #22d3ee;
+  --kgw-red: #f87171;
+  --kgw-yellow: #fbbf24;
+  --kgw-blue: #60a5fa;
+  --kgw-gray: #7a8e7a;
+  --kgw-surface: rgba(255, 255, 255, 0.03);
+  --kgw-surface-hover: rgba(74, 222, 128, 0.05);
+  --kgw-border: #1a1a26;
+  --kgw-border-hover: rgba(74, 222, 128, 0.4);
 }
 
 /* Link color override */
-.site-nav a, .main-content a:not(.nav-card):not(.badge) { color: var(--kgw-teal); }
-.site-nav a:hover, .main-content a:not(.nav-card):not(.badge):hover { color: #33e6c0; }
+.site-nav a, .main-content a:not(.nav-card):not(.badge) { color: var(--kgw-green); }
+.site-nav a:hover, .main-content a:not(.nav-card):not(.badge):hover { color: #6ee7a0; text-shadow: 0 0 6px rgba(74, 222, 128, 0.3); }
 
 /* Hero */
-.hero { text-align: center; padding: 3rem 1rem 2.5rem; margin-bottom: 2.5rem; border-bottom: 2px solid transparent; border-image: linear-gradient(90deg, transparent, var(--kgw-teal-border), transparent) 1; }
-.hero h1 { font-size: 2.8rem; font-weight: 800; letter-spacing: -0.02em; margin-bottom: 0.75rem; background: linear-gradient(135deg, #fff 30%, var(--kgw-teal)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
-.hero .tagline { font-size: 1.1rem; opacity: 0.7; max-width: 600px; margin: 0 auto 1.75rem; line-height: 1.65; }
+.hero { text-align: center; padding: 3rem 1rem 2.5rem; margin-bottom: 2.5rem; border-bottom: 2px solid transparent; border-image: linear-gradient(90deg, transparent, var(--kgw-green-border), transparent) 1; }
+.hero h1 { font-size: 2.8rem; font-weight: 800; letter-spacing: -0.02em; margin-bottom: 0.75rem; background: linear-gradient(135deg, #fff 30%, var(--kgw-green)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+.hero .tagline { font-size: 1.1rem; opacity: 0.7; max-width: 600px; margin: 0 auto 1.75rem; line-height: 1.65; color: #b8ccb8; }
 .hero .badges { display: flex; gap: 0.4rem; justify-content: center; flex-wrap: wrap; margin-top: 0; }
-.hero .badge { display: inline-block; padding: 0.2rem 0.65rem; border-radius: 4px; font-size: 0.72rem; font-weight: 600; letter-spacing: 0.02em; text-transform: uppercase; text-decoration: none; border: 1px solid transparent; }
-.hero .badge--core { background: rgba(0, 212, 170, 0.12); color: var(--kgw-teal); border-color: rgba(0, 212, 170, 0.25); }
-.hero .badge--api { background: rgba(91, 157, 245, 0.12); color: var(--kgw-blue); border-color: rgba(91, 157, 245, 0.25); }
-.hero .badge--security { background: rgba(245, 166, 35, 0.12); color: var(--kgw-amber); border-color: rgba(245, 166, 35, 0.25); }
-.hero .badge--infra { background: rgba(136, 146, 164, 0.12); color: var(--kgw-gray); border-color: rgba(136, 146, 164, 0.25); }
+.hero .badge { display: inline-block; padding: 0.2rem 0.65rem; border-radius: 2px; font-size: 0.72rem; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; text-decoration: none; border: 1px solid transparent; font-family: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', monospace; }
+.hero .badge--core { background: rgba(74, 222, 128, 0.12); color: var(--kgw-green); border-color: rgba(74, 222, 128, 0.25); }
+.hero .badge--api { background: rgba(34, 211, 238, 0.12); color: var(--kgw-cyan); border-color: rgba(34, 211, 238, 0.25); }
+.hero .badge--security { background: rgba(251, 191, 36, 0.12); color: var(--kgw-yellow); border-color: rgba(251, 191, 36, 0.25); }
+.hero .badge--infra { background: rgba(122, 142, 122, 0.12); color: var(--kgw-gray); border-color: rgba(122, 142, 122, 0.25); }
 
 /* Feature Cards */
 .features { display: grid !important; grid-template-columns: repeat(2, 1fr) !important; gap: 1rem; margin: 2rem 0; }
-.feature-card { padding: 1.25rem 1.25rem 1.25rem 1.5rem; background: var(--kgw-surface); border: 1px solid var(--kgw-border); border-left: 3px solid var(--kgw-teal-dim); border-radius: 6px; transition: border-color 0.2s, background 0.2s, transform 0.15s; }
-.feature-card:hover { background: var(--kgw-surface-hover); border-color: var(--kgw-border-hover); border-left-color: var(--kgw-teal); transform: translateY(-1px); }
-.feature-card h3 { margin: 0 0 0.4rem 0; font-size: 0.95rem; font-weight: 700; display: flex; align-items: center; gap: 0.5rem; }
-.feature-card h3 .fc-icon { display: inline-flex; align-items: center; justify-content: center; width: 26px; height: 26px; border-radius: 5px; flex-shrink: 0; font-size: 0.8rem; line-height: 1; }
-.feature-card p { font-size: 0.85rem; opacity: 0.7; margin-bottom: 0; line-height: 1.55; }
+.feature-card { padding: 1.25rem 1.25rem 1.25rem 1.5rem; background: var(--kgw-surface); border: 1px solid var(--kgw-border); border-left: 3px solid var(--kgw-green-dim); border-radius: 2px; transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease; }
+.feature-card:hover { background: var(--kgw-surface-hover); border-color: var(--kgw-border-hover); border-left-color: var(--kgw-green); box-shadow: 0 0 12px rgba(74, 222, 128, 0.1); }
+.feature-card h3 { margin: 0 0 0.4rem 0; font-size: 0.95rem; font-weight: 700; display: flex; align-items: center; gap: 0.5rem; text-transform: uppercase; letter-spacing: 0.05em; }
+.feature-card h3 .fc-icon { display: inline-flex; align-items: center; justify-content: center; width: 26px; height: 26px; border-radius: 2px; flex-shrink: 0; font-size: 0.8rem; line-height: 1; }
+.feature-card p { font-size: 0.85rem; opacity: 0.7; margin-bottom: 0; line-height: 1.55; color: #7a8e7a; }
 
 /* Category colors */
-.feature-card[data-cat="api"] { border-left-color: var(--kgw-blue); }
-.feature-card[data-cat="api"]:hover { border-left-color: var(--kgw-blue); }
-.feature-card[data-cat="api"] .fc-icon { background: rgba(91, 157, 245, 0.15); color: var(--kgw-blue); }
-.feature-card[data-cat="core"] { border-left-color: var(--kgw-teal-dim); }
-.feature-card[data-cat="core"]:hover { border-left-color: var(--kgw-teal); }
-.feature-card[data-cat="core"] .fc-icon { background: rgba(0, 212, 170, 0.15); color: var(--kgw-teal); }
-.feature-card[data-cat="security"] { border-left-color: var(--kgw-amber); }
-.feature-card[data-cat="security"]:hover { border-left-color: var(--kgw-amber); }
-.feature-card[data-cat="security"] .fc-icon { background: rgba(245, 166, 35, 0.15); color: var(--kgw-amber); }
-.feature-card[data-cat="feature"] { border-left-color: var(--kgw-indigo); }
-.feature-card[data-cat="feature"]:hover { border-left-color: var(--kgw-indigo); }
-.feature-card[data-cat="feature"] .fc-icon { background: rgba(129, 140, 248, 0.15); color: var(--kgw-indigo); }
+.feature-card[data-cat="api"] { border-left-color: var(--kgw-cyan); }
+.feature-card[data-cat="api"]:hover { border-left-color: var(--kgw-cyan); box-shadow: 0 0 12px rgba(34, 211, 238, 0.1); }
+.feature-card[data-cat="api"] .fc-icon { background: rgba(34, 211, 238, 0.15); color: var(--kgw-cyan); }
+.feature-card[data-cat="core"] { border-left-color: var(--kgw-green-dim); }
+.feature-card[data-cat="core"]:hover { border-left-color: var(--kgw-green); box-shadow: 0 0 12px rgba(74, 222, 128, 0.1); }
+.feature-card[data-cat="core"] .fc-icon { background: rgba(74, 222, 128, 0.15); color: var(--kgw-green); }
+.feature-card[data-cat="security"] { border-left-color: var(--kgw-yellow); }
+.feature-card[data-cat="security"]:hover { border-left-color: var(--kgw-yellow); box-shadow: 0 0 12px rgba(251, 191, 36, 0.1); }
+.feature-card[data-cat="security"] .fc-icon { background: rgba(251, 191, 36, 0.15); color: var(--kgw-yellow); }
+.feature-card[data-cat="feature"] { border-left-color: var(--kgw-blue); }
+.feature-card[data-cat="feature"]:hover { border-left-color: var(--kgw-blue); box-shadow: 0 0 12px rgba(96, 165, 250, 0.1); }
+.feature-card[data-cat="feature"] .fc-icon { background: rgba(96, 165, 250, 0.15); color: var(--kgw-blue); }
 
 /* Nav Cards */
 .nav-cards { display: grid !important; grid-template-columns: repeat(3, 1fr) !important; gap: 0.75rem; margin: 1.5rem 0; }
-.nav-card { display: flex !important; align-items: center; gap: 0.65rem; padding: 0.85rem 1rem; background: var(--kgw-surface); border: 1px solid var(--kgw-border); border-radius: 6px; text-decoration: none; color: inherit; font-weight: 600; font-size: 0.88rem; transition: border-color 0.2s, background 0.2s, transform 0.15s; }
-.nav-card:hover { border-color: var(--kgw-border-hover); background: var(--kgw-surface-hover); transform: translateY(-1px); text-decoration: none; color: inherit; }
-.nav-card .nav-icon { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border-radius: 6px; background: rgba(0, 212, 170, 0.1); color: var(--kgw-teal); font-size: 0.85rem; font-weight: 700; flex-shrink: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-.nav-card:hover .nav-icon { background: rgba(0, 212, 170, 0.2); }
+.nav-card { display: flex !important; align-items: center; gap: 0.65rem; padding: 0.85rem 1rem; background: var(--kgw-surface); border: 1px solid var(--kgw-border); border-radius: 2px; text-decoration: none; color: inherit; font-weight: 600; font-size: 0.88rem; transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease; }
+.nav-card:hover { border-color: var(--kgw-border-hover); background: var(--kgw-surface-hover); box-shadow: 0 0 12px rgba(74, 222, 128, 0.1); text-decoration: none; color: inherit; }
+.nav-card .nav-icon { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; border-radius: 2px; background: rgba(74, 222, 128, 0.1); color: var(--kgw-green); font-size: 0.85rem; font-weight: 700; flex-shrink: 0; font-family: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', monospace; }
+.nav-card:hover .nav-icon { background: rgba(74, 222, 128, 0.2); }
 
 /* Mermaid Diagrams */
 .mermaid { text-align: center; margin: 1.5rem 0; overflow-x: auto; -webkit-overflow-scrolling: touch; padding: 1rem 0; }
 .mermaid svg { max-width: none !important; height: auto; min-height: 200px; }
 .mermaid::-webkit-scrollbar { height: 6px; }
-.mermaid::-webkit-scrollbar-track { background: rgba(255, 255, 255, 0.03); border-radius: 3px; }
-.mermaid::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.12); border-radius: 3px; }
+.mermaid::-webkit-scrollbar-track { background: rgba(74, 222, 128, 0.03); border-radius: 2px; }
+.mermaid::-webkit-scrollbar-thumb { background: rgba(74, 222, 128, 0.15); border-radius: 2px; }
 
 /* Tables */
 .main-content table { border-collapse: collapse; width: 100%; font-size: 0.88rem; }
-.main-content th { background: rgba(0, 212, 170, 0.08); border-bottom: 2px solid var(--kgw-teal-border); font-weight: 700; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.04em; padding: 0.65rem 0.75rem; }
+.main-content th { background: rgba(74, 222, 128, 0.08); border-bottom: 2px solid var(--kgw-green-border); font-weight: 700; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.05em; padding: 0.65rem 0.75rem; }
 .main-content td { padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--kgw-border); }
-.main-content tr:hover td { background: rgba(255, 255, 255, 0.02); }
-.main-content td code { font-size: 0.82rem; background: rgba(0, 212, 170, 0.08); padding: 0.1em 0.35em; border-radius: 3px; }
+.main-content tr:hover td { background: rgba(74, 222, 128, 0.03); }
+.main-content td code { font-size: 0.82rem; background: rgba(74, 222, 128, 0.08); color: var(--kgw-green); padding: 0.1em 0.35em; border-radius: 2px; }
 
 /* Code Blocks */
-div.highlighter-rouge { border-radius: 6px; margin: 1rem 0; border: 1px solid var(--kgw-border); }
-code.highlighter-rouge { padding: 0.15em 0.4em; border-radius: 3px; font-size: 0.86em; background: rgba(0, 212, 170, 0.08); }
+div.highlighter-rouge { border-radius: 2px; margin: 1rem 0; border: 1px solid var(--kgw-border); }
+code.highlighter-rouge { padding: 0.15em 0.4em; border-radius: 2px; font-size: 0.86em; background: rgba(74, 222, 128, 0.08); color: var(--kgw-green); }
 
 /* Heading Anchors */
-.main-content h2 .anchor-heading svg, .main-content h3 .anchor-heading svg, .main-content h4 .anchor-heading svg { color: var(--kgw-teal-dim); opacity: 0; transition: opacity 0.15s; }
+.main-content h2 .anchor-heading svg, .main-content h3 .anchor-heading svg, .main-content h4 .anchor-heading svg { color: var(--kgw-green-dim); opacity: 0; transition: opacity 0.15s; }
 .main-content h2:hover .anchor-heading svg, .main-content h3:hover .anchor-heading svg, .main-content h4:hover .anchor-heading svg { opacity: 0.6; }
 
 /* Scrollbar */
 ::-webkit-scrollbar { width: 8px; height: 8px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.1); border-radius: 4px; }
-::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.18); }
+::-webkit-scrollbar-thumb { background: rgba(74, 222, 128, 0.12); border-radius: 2px; }
+::-webkit-scrollbar-thumb:hover { background: rgba(74, 222, 128, 0.2); }
 
 /* Responsive */
 @media (max-width: 800px) {

--- a/gh-pages/_includes/mermaid_config.html
+++ b/gh-pages/_includes/mermaid_config.html
@@ -2,20 +2,20 @@
   window.mermaid = {
     theme: "dark",
     themeVariables: {
-      primaryColor: "#0a3d33",
-      primaryTextColor: "#e0f2ee",
-      primaryBorderColor: "#00d4aa",
-      lineColor: "#4dd6b0",
-      secondaryColor: "#1a2332",
-      tertiaryColor: "#162028",
-      fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+      primaryColor: "#0b1a0b",
+      primaryTextColor: "#b8ccb8",
+      primaryBorderColor: "#4ade80",
+      lineColor: "#4ade80",
+      secondaryColor: "#101018",
+      tertiaryColor: "#0b0b10",
+      fontFamily: "'JetBrains Mono', 'SF Mono', 'Cascadia Code', ui-monospace, monospace",
       fontSize: "15px",
-      nodeBorder: "#00d4aa",
-      mainBkg: "#0a3d33",
-      clusterBkg: "rgba(0, 212, 170, 0.06)",
-      clusterBorder: "rgba(0, 212, 170, 0.2)",
-      edgeLabelBackground: "#1a2332",
-      nodeTextColor: "#e0f2ee"
+      nodeBorder: "#4ade80",
+      mainBkg: "#0b1a0b",
+      clusterBkg: "rgba(74, 222, 128, 0.06)",
+      clusterBorder: "rgba(74, 222, 128, 0.2)",
+      edgeLabelBackground: "#101018",
+      nodeTextColor: "#b8ccb8"
     }
   };
 </script>

--- a/gh-pages/_sass/custom/custom.scss
+++ b/gh-pages/_sass/custom/custom.scss
@@ -1,34 +1,377 @@
 // ============================================================
-// Kiro Gateway — Infrastructure Command Center Theme
+// Kiro Gateway — CRT Phosphor Terminal Theme
+// Matches frontend/src/styles/variables.css aesthetic
 // ============================================================
 
-// Color tokens
+// Import JetBrains Mono from Google Fonts
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+
+// ============================================================
+// Color Tokens (from frontend variables.css)
+// ============================================================
 :root {
-  --kgw-teal: #00d4aa;
-  --kgw-teal-dim: #009e7e;
-  --kgw-teal-glow: rgba(0, 212, 170, 0.15);
-  --kgw-teal-border: rgba(0, 212, 170, 0.3);
-  --kgw-blue: #5b9df5;
-  --kgw-amber: #f5a623;
-  --kgw-rose: #f56565;
-  --kgw-indigo: #818cf8;
-  --kgw-gray: #8892a4;
-  --kgw-surface: rgba(255, 255, 255, 0.04);
-  --kgw-surface-hover: rgba(255, 255, 255, 0.07);
-  --kgw-border: rgba(255, 255, 255, 0.08);
-  --kgw-border-hover: rgba(0, 212, 170, 0.4);
+  // Backgrounds
+  --kgw-bg: #060609;
+  --kgw-bg-raised: #0b0b10;
+  --kgw-surface: #101018;
+  --kgw-surface-hover: #16161f;
+
+  // Borders
+  --kgw-border: #1a1a26;
+  --kgw-border-subtle: #141420;
+
+  // Primary colors
+  --kgw-green: #4ade80;
+  --kgw-green-dim: rgba(74, 222, 128, 0.10);
+  --kgw-green-glow: rgba(74, 222, 128, 0.14);
+  --kgw-cyan: #22d3ee;
+  --kgw-cyan-dim: rgba(34, 211, 238, 0.10);
+
+  // Accent colors
+  --kgw-red: #f87171;
+  --kgw-red-dim: rgba(248, 113, 113, 0.10);
+  --kgw-yellow: #fbbf24;
+  --kgw-yellow-dim: rgba(251, 191, 36, 0.10);
+  --kgw-blue: #60a5fa;
+  --kgw-blue-dim: rgba(96, 165, 250, 0.10);
+
+  // Text
+  --kgw-text: #b8ccb8;
+  --kgw-text-secondary: #7a8e7a;
+  --kgw-text-tertiary: #6a7e6a;
+
+  // Typography
+  --kgw-font-mono: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', monospace;
+
+  // Radius (sharp, not rounded)
+  --kgw-radius: 2px;
+  --kgw-radius-sm: 1px;
+  --kgw-radius-lg: 3px;
+
+  // Glow effects
+  --kgw-glow-sm: 0 0 6px rgba(74, 222, 128, 0.15);
+  --kgw-glow-md: 0 0 12px rgba(74, 222, 128, 0.2);
+  --kgw-glow-lg: 0 0 24px rgba(74, 222, 128, 0.25);
 }
 
-// Override just-the-docs link color
-.site-nav,
-.main-content {
-  a:not(.nav-card):not(.badge) {
-    color: var(--kgw-teal);
+// ============================================================
+// Global Overrides — just-the-docs theme
+// ============================================================
 
-    &:hover {
-      color: #33e6c0;
+// Body background + font
+.side-bar,
+.main-content-wrap,
+body {
+  background-color: var(--kgw-bg) !important;
+  font-family: var(--kgw-font-mono) !important;
+  color: var(--kgw-text);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+// ============================================================
+// CRT Effects (from frontend global.css)
+// ============================================================
+
+// Scanline overlay
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent 0px,
+    transparent 2px,
+    rgba(0, 0, 0, 0.08) 2px,
+    rgba(0, 0, 0, 0.08) 4px
+  );
+  pointer-events: none;
+  z-index: 9999;
+}
+
+// Vignette + dot-grid
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 50% 50%, transparent 60%, rgba(0, 0, 0, 0.5) 100%),
+    radial-gradient(circle 1px at center, rgba(74, 222, 128, 0.03) 0%, transparent 100%);
+  background-size: 100% 100%, 20px 20px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+// Selection
+::selection {
+  background: rgba(74, 222, 128, 0.2);
+  color: var(--kgw-green);
+}
+
+// Focus visible
+:focus-visible {
+  outline: 2px solid var(--kgw-green);
+  outline-offset: 2px;
+}
+
+// Reduced motion
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+// ============================================================
+// Sidebar
+// ============================================================
+.side-bar {
+  background-color: var(--kgw-bg-raised) !important;
+  border-right: 1px solid var(--kgw-green-dim) !important;
+  box-shadow: 1px 0 20px rgba(74, 222, 128, 0.03);
+
+  .site-title {
+    font-family: var(--kgw-font-mono) !important;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--kgw-green) !important;
+    text-shadow: var(--kgw-glow-md);
+  }
+}
+
+// Navigation links
+.nav-list {
+  font-family: var(--kgw-font-mono);
+
+  .nav-list-item {
+    font-size: 0.82rem;
+
+    .nav-list-link {
+      color: var(--kgw-text-secondary);
+      font-family: var(--kgw-font-mono);
+      border-radius: var(--kgw-radius-sm);
+      transition: all 0.15s ease;
+
+      &:hover {
+        background-color: var(--kgw-surface);
+        color: var(--kgw-text);
+      }
+
+      &.active {
+        background-color: var(--kgw-green-glow);
+        color: var(--kgw-green);
+        text-shadow: var(--kgw-glow-sm);
+        font-weight: 600;
+        border-left: 2px solid var(--kgw-green);
+      }
     }
   }
+}
+
+// Site footer
+.site-footer {
+  font-family: var(--kgw-font-mono);
+  font-size: 0.72rem;
+  color: var(--kgw-text-tertiary);
+  border-top: 1px solid var(--kgw-border);
+
+  a {
+    color: var(--kgw-green) !important;
+
+    &:hover {
+      text-shadow: var(--kgw-glow-sm);
+    }
+  }
+}
+
+// ============================================================
+// Main Content
+// ============================================================
+.main-content {
+  font-family: var(--kgw-font-mono);
+  color: var(--kgw-text);
+
+  // Links
+  a:not(.nav-card):not(.badge) {
+    color: var(--kgw-green);
+
+    &:hover {
+      color: var(--kgw-green);
+      text-shadow: var(--kgw-glow-sm);
+    }
+  }
+
+  // Headings — phosphor glow
+  h1, h2, h3, h4, h5, h6 {
+    font-family: var(--kgw-font-mono) !important;
+    color: var(--kgw-green);
+    text-shadow: var(--kgw-glow-sm);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  h1 {
+    font-size: 1.6rem;
+    border-bottom: 1px solid var(--kgw-border);
+    padding-bottom: 0.5rem;
+  }
+
+  h2 {
+    font-size: 1.2rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-bottom: 1px solid var(--kgw-border);
+    padding-bottom: 0.4rem;
+    margin-top: 2.5rem;
+
+    &::before {
+      content: '// ';
+      color: var(--kgw-text-tertiary);
+    }
+  }
+
+  h3 {
+    font-size: 1rem;
+  }
+
+  // Paragraphs
+  p {
+    color: var(--kgw-text);
+    line-height: 1.6;
+  }
+
+  // Strong / bold
+  strong {
+    color: var(--kgw-text);
+    font-weight: 600;
+  }
+
+  // Lists
+  ul, ol {
+    color: var(--kgw-text);
+
+    li {
+      margin-bottom: 0.3rem;
+    }
+  }
+
+  // Heading anchors
+  h2, h3, h4 {
+    .anchor-heading svg {
+      color: var(--kgw-text-tertiary);
+      opacity: 0;
+      transition: opacity 0.15s;
+    }
+
+    &:hover .anchor-heading svg {
+      opacity: 0.6;
+    }
+  }
+}
+
+// ============================================================
+// Tables — CRT styled
+// ============================================================
+.main-content {
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.82rem;
+    font-family: var(--kgw-font-mono);
+    border: 1px solid var(--kgw-border);
+    border-radius: var(--kgw-radius);
+    overflow: hidden;
+  }
+
+  th {
+    background: var(--kgw-bg-raised);
+    border-bottom: 1px double rgba(74, 222, 128, 0.15);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.72rem;
+    letter-spacing: 0.06em;
+    padding: 0.65rem 0.75rem;
+    color: var(--kgw-text-tertiary);
+    text-align: left;
+  }
+
+  td {
+    padding: 0.55rem 0.75rem;
+    border-bottom: 1px solid var(--kgw-border-subtle);
+    color: var(--kgw-text-secondary);
+  }
+
+  tr:hover td {
+    background: var(--kgw-surface-hover);
+  }
+
+  td:first-child {
+    color: var(--kgw-green);
+    font-weight: 500;
+  }
+
+  td code {
+    font-size: 0.8rem;
+    background: rgba(74, 222, 128, 0.08);
+    padding: 0.1em 0.35em;
+    border-radius: var(--kgw-radius-sm);
+    color: var(--kgw-green);
+  }
+}
+
+// ============================================================
+// Code Blocks — green-tinted CRT
+// ============================================================
+div.highlighter-rouge {
+  border-radius: var(--kgw-radius);
+  margin: 1rem 0;
+  border: 1px solid var(--kgw-border);
+  background: var(--kgw-bg-raised) !important;
+
+  pre {
+    background: var(--kgw-bg-raised) !important;
+    font-family: var(--kgw-font-mono);
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: var(--kgw-text);
+  }
+
+  code {
+    font-family: var(--kgw-font-mono);
+    background: transparent !important;
+    color: var(--kgw-text);
+  }
+}
+
+// Inline code
+code.highlighter-rouge,
+.main-content code:not(.highlighter-rouge) {
+  padding: 0.15em 0.4em;
+  border-radius: var(--kgw-radius-sm);
+  font-size: 0.84em;
+  background: rgba(74, 222, 128, 0.08);
+  color: var(--kgw-green);
+  font-family: var(--kgw-font-mono);
+}
+
+// Pre blocks
+pre.highlight {
+  background: var(--kgw-bg-raised) !important;
+}
+
+// ============================================================
+// Blockquotes
+// ============================================================
+.main-content blockquote {
+  border-left: 3px solid var(--kgw-green);
+  background: var(--kgw-surface);
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  border-radius: var(--kgw-radius);
+  color: var(--kgw-text-secondary);
+  font-size: 0.88rem;
 }
 
 // ============================================================
@@ -38,8 +381,7 @@
   text-align: center;
   padding: 3rem 1rem 2.5rem;
   margin-bottom: 2.5rem;
-  border-bottom: 2px solid transparent;
-  border-image: linear-gradient(90deg, transparent, var(--kgw-teal-border), transparent) 1;
+  border-bottom: 1px solid var(--kgw-border);
   position: relative;
 }
 
@@ -48,15 +390,22 @@
   font-weight: 800;
   letter-spacing: -0.02em;
   margin-bottom: 0.75rem;
-  background: linear-gradient(135deg, #fff 30%, var(--kgw-teal));
+  background: linear-gradient(135deg, #fff 30%, var(--kgw-green));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  text-shadow: none;
+  border-bottom: none;
+  padding-bottom: 0;
+
+  &::before {
+    content: none;
+  }
 }
 
 .hero .tagline {
-  font-size: 1.1rem;
-  opacity: 0.7;
+  font-size: 1rem;
+  color: var(--kgw-text-secondary);
   max-width: 600px;
   margin: 0 auto 1.75rem;
   line-height: 1.65;
@@ -73,41 +422,48 @@
 .hero .badge {
   display: inline-block;
   padding: 0.2rem 0.65rem;
-  border-radius: 4px;
-  font-size: 0.72rem;
+  border-radius: var(--kgw-radius);
+  font-size: 0.68rem;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
   text-decoration: none;
   border: 1px solid transparent;
+  font-family: var(--kgw-font-mono);
 }
 
 .hero .badge--core {
-  background: rgba(0, 212, 170, 0.12);
-  color: var(--kgw-teal);
-  border-color: rgba(0, 212, 170, 0.25);
+  background: rgba(74, 222, 128, 0.10);
+  color: var(--kgw-green);
+  border-color: rgba(74, 222, 128, 0.25);
 }
 
 .hero .badge--api {
-  background: rgba(91, 157, 245, 0.12);
-  color: var(--kgw-blue);
-  border-color: rgba(91, 157, 245, 0.25);
+  background: rgba(34, 211, 238, 0.10);
+  color: var(--kgw-cyan);
+  border-color: rgba(34, 211, 238, 0.25);
 }
 
 .hero .badge--security {
-  background: rgba(245, 166, 35, 0.12);
-  color: var(--kgw-amber);
-  border-color: rgba(245, 166, 35, 0.25);
+  background: rgba(251, 191, 36, 0.10);
+  color: var(--kgw-yellow);
+  border-color: rgba(251, 191, 36, 0.25);
 }
 
 .hero .badge--infra {
-  background: rgba(136, 146, 164, 0.12);
-  color: var(--kgw-gray);
-  border-color: rgba(136, 146, 164, 0.25);
+  background: rgba(96, 165, 250, 0.10);
+  color: var(--kgw-blue);
+  border-color: rgba(96, 165, 250, 0.25);
+}
+
+.hero .badge--provider {
+  background: rgba(248, 113, 113, 0.10);
+  color: var(--kgw-red);
+  border-color: rgba(248, 113, 113, 0.25);
 }
 
 // ============================================================
-// Feature Cards
+// Feature Cards — sharp borders, left accent, hover glow
 // ============================================================
 .features {
   display: grid !important;
@@ -120,26 +476,33 @@
   padding: 1.25rem 1.25rem 1.25rem 1.5rem;
   background: var(--kgw-surface);
   border: 1px solid var(--kgw-border);
-  border-left: 3px solid var(--kgw-teal-dim);
-  border-radius: 6px;
-  transition: border-color 0.2s, background 0.2s, transform 0.15s;
+  border-left: 3px solid var(--kgw-green-dim);
+  border-radius: var(--kgw-radius);
+  transition: border-color 0.2s, box-shadow 0.2s;
   position: relative;
-}
 
-.feature-card:hover {
-  background: var(--kgw-surface-hover);
-  border-color: var(--kgw-border-hover);
-  border-left-color: var(--kgw-teal);
-  transform: translateY(-1px);
+  &:hover {
+    border-color: var(--kgw-border);
+    border-left-color: var(--kgw-green);
+    box-shadow: var(--kgw-glow-sm);
+  }
 }
 
 .feature-card h3 {
   margin: 0 0 0.4rem 0;
-  font-size: 0.95rem;
-  font-weight: 700;
+  font-size: 0.88rem;
+  font-weight: 600;
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--kgw-green);
+  text-shadow: var(--kgw-glow-sm);
+
+  &::before {
+    content: none;
+  }
 }
 
 .feature-card h3 .fc-icon {
@@ -148,66 +511,77 @@
   justify-content: center;
   width: 26px;
   height: 26px;
-  border-radius: 5px;
+  border-radius: var(--kgw-radius);
   flex-shrink: 0;
   font-size: 0.8rem;
   line-height: 1;
 }
 
 .feature-card p {
-  font-size: 0.85rem;
-  opacity: 0.7;
+  font-size: 0.82rem;
+  color: var(--kgw-text-secondary);
   margin-bottom: 0;
   line-height: 1.55;
 }
 
 // Category colors for feature cards
 .feature-card[data-cat="api"] {
-  border-left-color: var(--kgw-blue);
+  border-left-color: var(--kgw-cyan);
 
-  &:hover { border-left-color: var(--kgw-blue); }
+  &:hover { border-left-color: var(--kgw-cyan); box-shadow: 0 0 8px rgba(34, 211, 238, 0.12); }
 
   .fc-icon {
-    background: rgba(91, 157, 245, 0.15);
-    color: var(--kgw-blue);
+    background: rgba(34, 211, 238, 0.12);
+    color: var(--kgw-cyan);
   }
 }
 
 .feature-card[data-cat="core"] {
-  border-left-color: var(--kgw-teal-dim);
+  border-left-color: rgba(74, 222, 128, 0.3);
 
-  &:hover { border-left-color: var(--kgw-teal); }
+  &:hover { border-left-color: var(--kgw-green); box-shadow: var(--kgw-glow-sm); }
 
   .fc-icon {
-    background: rgba(0, 212, 170, 0.15);
-    color: var(--kgw-teal);
+    background: rgba(74, 222, 128, 0.12);
+    color: var(--kgw-green);
   }
 }
 
 .feature-card[data-cat="security"] {
-  border-left-color: var(--kgw-amber);
+  border-left-color: rgba(251, 191, 36, 0.4);
 
-  &:hover { border-left-color: var(--kgw-amber); }
+  &:hover { border-left-color: var(--kgw-yellow); box-shadow: 0 0 8px rgba(251, 191, 36, 0.12); }
 
   .fc-icon {
-    background: rgba(245, 166, 35, 0.15);
-    color: var(--kgw-amber);
+    background: rgba(251, 191, 36, 0.12);
+    color: var(--kgw-yellow);
   }
 }
 
 .feature-card[data-cat="feature"] {
-  border-left-color: var(--kgw-indigo);
+  border-left-color: rgba(96, 165, 250, 0.4);
 
-  &:hover { border-left-color: var(--kgw-indigo); }
+  &:hover { border-left-color: var(--kgw-blue); box-shadow: 0 0 8px rgba(96, 165, 250, 0.12); }
 
   .fc-icon {
-    background: rgba(129, 140, 248, 0.15);
-    color: var(--kgw-indigo);
+    background: rgba(96, 165, 250, 0.12);
+    color: var(--kgw-blue);
+  }
+}
+
+.feature-card[data-cat="provider"] {
+  border-left-color: rgba(248, 113, 113, 0.4);
+
+  &:hover { border-left-color: var(--kgw-red); box-shadow: 0 0 8px rgba(248, 113, 113, 0.12); }
+
+  .fc-icon {
+    background: rgba(248, 113, 113, 0.12);
+    color: var(--kgw-red);
   }
 }
 
 // ============================================================
-// Navigation Cards
+// Navigation Cards — sharp, left accent, hover glow
 // ============================================================
 .nav-cards {
   display: grid !important;
@@ -223,43 +597,45 @@
   padding: 0.85rem 1rem;
   background: var(--kgw-surface);
   border: 1px solid var(--kgw-border);
-  border-radius: 6px;
+  border-left: 3px solid var(--kgw-green-dim);
+  border-radius: var(--kgw-radius);
   text-decoration: none;
-  color: inherit;
+  color: var(--kgw-text) !important;
   font-weight: 600;
-  font-size: 0.88rem;
-  transition: border-color 0.2s, background 0.2s, transform 0.15s;
-}
+  font-size: 0.82rem;
+  font-family: var(--kgw-font-mono);
+  transition: border-color 0.2s, box-shadow 0.2s;
 
-.nav-card:hover {
-  border-color: var(--kgw-border-hover);
-  background: var(--kgw-surface-hover);
-  transform: translateY(-1px);
-  text-decoration: none;
-  color: inherit;
+  &:hover {
+    border-left-color: var(--kgw-green);
+    box-shadow: var(--kgw-glow-sm);
+    text-decoration: none;
+    color: var(--kgw-green) !important;
+  }
 }
 
 .nav-card .nav-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: 6px;
-  background: rgba(0, 212, 170, 0.1);
-  color: var(--kgw-teal);
-  font-size: 0.85rem;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--kgw-radius);
+  background: rgba(74, 222, 128, 0.10);
+  color: var(--kgw-green);
+  font-size: 0.82rem;
   font-weight: 700;
   flex-shrink: 0;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--kgw-font-mono);
 }
 
 .nav-card:hover .nav-icon {
-  background: rgba(0, 212, 170, 0.2);
+  background: rgba(74, 222, 128, 0.20);
+  box-shadow: var(--kgw-glow-sm);
 }
 
 // ============================================================
-// Mermaid Diagrams (CRITICAL FIX)
+// Mermaid Diagrams
 // ============================================================
 .mermaid {
   text-align: center;
@@ -276,99 +652,50 @@
 }
 
 .mermaid::-webkit-scrollbar {
-  height: 6px;
+  height: 4px;
 }
 
 .mermaid::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 3px;
+  background: transparent;
 }
 
 .mermaid::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.12);
-  border-radius: 3px;
+  background: var(--kgw-border);
+  border-radius: 0;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.2);
+    background: var(--kgw-green-dim);
   }
 }
 
 // ============================================================
-// Tables
+// Search
 // ============================================================
-.main-content {
-  table {
-    border-collapse: collapse;
-    width: 100%;
-    font-size: 0.88rem;
-  }
+.search-input {
+  font-family: var(--kgw-font-mono);
+  background: var(--kgw-bg) !important;
+  border: 1px solid var(--kgw-border) !important;
+  color: var(--kgw-text) !important;
+  border-radius: var(--kgw-radius-sm) !important;
 
-  th {
-    background: rgba(0, 212, 170, 0.08);
-    border-bottom: 2px solid var(--kgw-teal-border);
-    font-weight: 700;
-    text-transform: uppercase;
-    font-size: 0.75rem;
-    letter-spacing: 0.04em;
-    padding: 0.65rem 0.75rem;
-  }
-
-  td {
-    padding: 0.55rem 0.75rem;
-    border-bottom: 1px solid var(--kgw-border);
-  }
-
-  tr:hover td {
-    background: rgba(255, 255, 255, 0.02);
-  }
-
-  td code {
-    font-size: 0.82rem;
-    background: rgba(0, 212, 170, 0.08);
-    padding: 0.1em 0.35em;
-    border-radius: 3px;
+  &:focus {
+    border-color: var(--kgw-green) !important;
+    box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.08) !important;
   }
 }
 
-// ============================================================
-// Code Blocks
-// ============================================================
-div.highlighter-rouge {
-  border-radius: 6px;
-  margin: 1rem 0;
-  border: 1px solid var(--kgw-border);
-}
-
-code.highlighter-rouge {
-  padding: 0.15em 0.4em;
-  border-radius: 3px;
-  font-size: 0.86em;
-  background: rgba(0, 212, 170, 0.08);
+.search-results {
+  background: var(--kgw-surface) !important;
+  border: 1px solid var(--kgw-border) !important;
+  font-family: var(--kgw-font-mono);
 }
 
 // ============================================================
-// Heading Anchors
-// ============================================================
-.main-content {
-  h2, h3, h4 {
-    .anchor-heading svg {
-      color: var(--kgw-teal-dim);
-      opacity: 0;
-      transition: opacity 0.15s;
-    }
-
-    &:hover .anchor-heading svg {
-      opacity: 0.6;
-    }
-  }
-}
-
-// ============================================================
-// Global Scrollbar
+// Scrollbar — thin, CRT style
 // ============================================================
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 4px;
+  height: 4px;
 }
 
 ::-webkit-scrollbar-track {
@@ -376,11 +703,52 @@ code.highlighter-rouge {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 4px;
+  background: var(--kgw-border);
+  border-radius: 0;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.18);
+    background: var(--kgw-green-dim);
+  }
+}
+
+// ============================================================
+// Breadcrumbs / page header
+// ============================================================
+.breadcrumb-nav {
+  font-family: var(--kgw-font-mono);
+  font-size: 0.72rem;
+  color: var(--kgw-text-tertiary);
+
+  a {
+    color: var(--kgw-text-secondary) !important;
+
+    &:hover {
+      color: var(--kgw-green) !important;
+    }
+  }
+}
+
+// ============================================================
+// Back to top
+// ============================================================
+.back-to-top {
+  font-family: var(--kgw-font-mono);
+  color: var(--kgw-text-tertiary);
+  font-size: 0.72rem;
+
+  &:hover {
+    color: var(--kgw-green);
+  }
+}
+
+// ============================================================
+// Callouts
+// ============================================================
+.main-content {
+  .warning, .note, .tip {
+    font-family: var(--kgw-font-mono);
+    border-radius: var(--kgw-radius);
+    font-size: 0.85rem;
   }
 }
 
@@ -411,7 +779,7 @@ code.highlighter-rouge {
   }
 
   .hero .badge {
-    font-size: 0.65rem;
+    font-size: 0.62rem;
     padding: 0.15rem 0.5rem;
   }
 }

--- a/gh-pages/docs/api-reference.md
+++ b/gh-pages/docs/api-reference.md
@@ -722,6 +722,9 @@ All web UI API endpoints are under `/_ui/api/`. See the [Web Dashboard](web-ui.h
 | `POST` | `/_ui/api/auth/logout` | End session |
 | `*` | `/_ui/api/kiro/*` | Kiro token management |
 | `*` | `/_ui/api/keys/*` | API key management |
+| `*` | `/_ui/api/copilot/*` | GitHub Copilot OAuth (connect/callback/status/disconnect) |
+| `*` | `/_ui/api/qwen/*` | Qwen Coder device flow (connect/poll/status/disconnect) |
+| `*` | `/_ui/api/providers/*` | Provider OAuth relay and priority management |
 
 ### Admin-Only (Session + CSRF + Admin Role)
 

--- a/gh-pages/docs/architecture/authentication.md
+++ b/gh-pages/docs/architecture/authentication.md
@@ -9,9 +9,15 @@ permalink: /architecture/authentication/
 # Authentication System
 {: .no_toc }
 
-Kiro Gateway's authentication model depends on the deployment mode:
+Kiro Gateway has three layers of authentication:
 
-- **Full Deployment** uses per-user API keys for proxy endpoints (`/v1/*`), Google SSO with PKCE for the web UI (`/_ui/api/*`), and per-user Kiro credentials stored in PostgreSQL.
+1. **Client authentication** — API keys for proxy endpoints (`/v1/*`), Google SSO for the web UI (`/_ui/api/*`)
+2. **Provider authentication** — Per-user credentials for each AI provider (Kiro, Anthropic, OpenAI, Gemini, Copilot, Qwen)
+3. **Provider OAuth flows** — Web UI flows for connecting provider accounts (GitHub OAuth for Copilot, device flow for Qwen, PKCE relay for Anthropic)
+
+The deployment mode determines which features are active:
+
+- **Full Deployment** uses per-user API keys for proxy endpoints, Google SSO with PKCE for the web UI, per-user Kiro credentials stored in PostgreSQL, and multi-provider OAuth for connecting additional AI providers.
 - **Proxy-Only Mode** uses a single `PROXY_API_KEY` for all requests and a single set of Kiro credentials obtained via an AWS SSO device code flow on first boot.
 
 ## Table of Contents
@@ -109,7 +115,7 @@ flowchart TB
         MW["Auth Middleware"]
         CLIENT -->|"Authorization: Bearer {api-key}<br/>or x-api-key: {api-key}"| MW
         MW -->|"SHA-256 hash → cache/DB lookup"| LOOKUP["Identify user + key"]
-        LOOKUP -->|Valid| INJECT["Inject per-user Kiro creds"]
+        LOOKUP -->|Valid| INJECT["Inject user identity"]
         LOOKUP -->|Invalid| REJECT["401 Unauthorized"]
         INJECT --> HANDLER["Route Handler"]
     end
@@ -123,8 +129,18 @@ flowchart TB
         SESSION_CHECK -->|No| LOGIN["Redirect to Google SSO"]
     end
 
-    subgraph BackendAuth["Backend Authentication (Kiro API)"]
-        HANDLER --> AUTHMGR["AuthManager"]
+    subgraph ProviderAuth["Provider Resolution (per-request)"]
+        HANDLER --> REGISTRY["ProviderRegistry"]
+        REGISTRY -->|"resolve_provider(user_id, model)"| PROV_CACHE{"Credential cache<br/>(5-min TTL)?"}
+        PROV_CACHE -->|Hit| SELECT["Select by priority"]
+        PROV_CACHE -->|Miss| LOAD_CREDS["Load from DB +<br/>refresh if expiring"]
+        LOAD_CREDS --> SELECT
+        SELECT --> KIRO_PATH["Kiro: AWS SSO OIDC"]
+        SELECT --> DIRECT_PATH["Direct: Anthropic/OpenAI/<br/>Gemini/Copilot/Qwen"]
+    end
+
+    subgraph BackendAuth["Kiro Token Management"]
+        KIRO_PATH --> AUTHMGR["AuthManager"]
         AUTHMGR -->|"get per-user token"| TOKEN_CACHE{"Token in cache<br/>(4-min TTL)?"}
         TOKEN_CACHE -->|Yes| USE_TOKEN["Use cached token"]
         TOKEN_CACHE -->|No| REFRESH["Refresh via AWS SSO OIDC"]
@@ -134,10 +150,15 @@ flowchart TB
         USE_TOKEN --> KIRO["Kiro API<br/>(Bearer token)"]
     end
 
+    subgraph DirectAuth["Direct Provider Auth"]
+        DIRECT_PATH --> PROVIDER_API["Provider API<br/>(Bearer token / API key)"]
+    end
+
     subgraph Storage["Credential Storage"]
         PG[("PostgreSQL")]
-        AUTHMGR -.->|"Load per-user credentials"| PG
-        WEBHANDLER -->|"Manage users, API keys"| PG
+        AUTHMGR -.->|"Load per-user Kiro credentials"| PG
+        REGISTRY -.->|"Load provider tokens<br/>(user_provider_tokens table)"| PG
+        WEBHANDLER -->|"Manage users, API keys,<br/>provider connections"| PG
     end
 ```
 
@@ -321,6 +342,154 @@ The SSO region may differ from the API region (e.g., SSO in `us-east-1` but API 
 
 ---
 
+## Multi-Provider Authentication
+
+Beyond the default Kiro provider, users can connect additional AI providers through the web UI. Each provider has its own OAuth flow and credential storage. Provider tokens are stored in the `user_provider_tokens` PostgreSQL table and cached in the `ProviderRegistry` with a 5-minute TTL.
+
+### Provider Credential Storage
+
+All provider tokens are stored per-user in PostgreSQL:
+
+| Column | Description |
+|--------|-------------|
+| `user_id` | Foreign key to users table |
+| `provider` | Provider identifier (`anthropic`, `openai`, `gemini`, `copilot`, `qwen`) |
+| `access_token` | Current access token (encrypted at rest) |
+| `refresh_token` | Refresh token for OAuth providers |
+| `expires_at` | Token expiry timestamp |
+| `base_url` | Optional API endpoint override |
+| `priority` | Provider priority (lower = preferred) |
+| `metadata` | Provider-specific metadata (JSON) |
+
+### GitHub Copilot OAuth Flow
+
+Copilot authentication uses a two-step process: GitHub OAuth for user authorization, then a Copilot-specific token exchange. Implemented in `backend/src/web_ui/copilot_auth.rs`.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Browser
+    participant Backend as Backend API
+    participant GitHub as GitHub OAuth
+    participant Copilot as Copilot Token API
+
+    User->>Browser: Click "Connect Copilot"
+    Browser->>Backend: GET /_ui/api/providers/copilot/auth
+
+    Backend->>Backend: Generate state parameter
+    Backend->>Backend: Store state in oauth_pending
+    Backend-->>Browser: 302 Redirect to GitHub
+
+    Browser->>GitHub: Authorization request (scope: read:user)
+    User->>GitHub: Authorize application
+    GitHub-->>Browser: 302 Redirect with code + state
+
+    Browser->>Backend: GET /_ui/api/providers/copilot/callback?code=...&state=...
+    Backend->>Backend: Verify state matches oauth_pending
+    Backend->>GitHub: Exchange code for GitHub access_token
+    GitHub-->>Backend: {access_token}
+
+    Backend->>GitHub: GET /user (verify GitHub identity)
+    GitHub-->>Backend: {login: "username"}
+
+    Backend->>Copilot: GET /copilot_internal/v2/token
+    Note over Backend,Copilot: Headers: Authorization, Editor-Version,<br/>Editor-Plugin-Version, Copilot-Integration-Id
+    Copilot-->>Backend: {token, expires_at, endpoints.api}
+
+    Backend->>Backend: Store Copilot token + base_url in DB
+    Backend->>Backend: Cache in copilot_token_cache
+    Backend-->>Browser: Redirect to /_ui/ (success)
+```
+
+The Copilot token includes a `base_url` from the `endpoints.api` field, which may vary (e.g., `https://api.githubcopilot.com` vs `https://api.business.githubcopilot.com` for enterprise). Tokens are cached in `copilot_token_cache: Arc<DashMap<Uuid, (String, String, Instant)>>` mapping user IDs to `(token, base_url, cached_at)`.
+
+### Qwen Coder Device Flow
+
+Qwen uses RFC 8628 (OAuth Device Authorization Grant) — the user authorizes on a separate device/browser. Implemented in `backend/src/web_ui/qwen_auth.rs`.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Browser
+    participant Backend as Backend API
+    participant Qwen as Qwen OAuth API
+
+    User->>Browser: Click "Connect Qwen"
+    Browser->>Backend: POST /_ui/api/providers/qwen/device-code
+
+    Backend->>Backend: Generate PKCE code_verifier + code_challenge
+    Backend->>Qwen: POST /api/v1/oauth2/device/code
+    Note over Backend,Qwen: {client_id, code_challenge, code_challenge_method}
+    Qwen-->>Backend: {device_code, user_code, verification_uri, interval}
+
+    Backend->>Backend: Store {device_code, code_verifier, user_id} in qwen_device_pending
+    Backend-->>Browser: {device_code, user_code, verification_uri, interval}
+
+    Note over Browser: Display user_code and verification_uri
+    User->>Qwen: Open verification_uri, enter user_code, authorize
+
+    loop Poll for token (every interval seconds)
+        Browser->>Backend: GET /_ui/api/providers/qwen/device-poll?device_code=...
+        Backend->>Qwen: POST /api/v1/oauth2/token
+        Note over Backend,Qwen: {client_id, device_code, code_verifier,<br/>grant_type: urn:ietf:params:oauth:grant-type:device_code}
+        alt Authorization pending
+            Qwen-->>Backend: {error: "authorization_pending"}
+            Backend-->>Browser: {status: "pending"}
+        else Authorized
+            Qwen-->>Backend: {access_token, refresh_token, expires_in}
+            Backend->>Backend: Store tokens in user_provider_tokens
+            Backend->>Backend: Remove from qwen_device_pending
+            Backend-->>Browser: {status: "complete"}
+        else Expired / Denied
+            Qwen-->>Backend: {error: "expired_token" | "access_denied"}
+            Backend-->>Browser: {status: "error", message: "..."}
+        end
+    end
+```
+
+Pending device flow states are stored in `qwen_device_pending: Arc<DashMap<String, QwenDevicePending>>` with a 10-minute TTL and 10k capacity cap.
+
+### Anthropic OAuth Relay (PKCE)
+
+Anthropic uses a standard OAuth 2.0 authorization code flow with PKCE. The gateway acts as a relay, redirecting the user to `claude.ai/oauth/authorize` and exchanging the code for tokens. Implemented in `backend/src/web_ui/provider_oauth.rs`.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Browser
+    participant Backend as Backend API
+    participant Anthropic as Anthropic OAuth
+
+    User->>Browser: Click "Connect Anthropic"
+    Browser->>Backend: GET /_ui/api/providers/anthropic/auth
+
+    Backend->>Backend: Generate PKCE code_verifier + code_challenge
+    Backend->>Backend: Generate state parameter
+    Backend->>Backend: Store {pkce_verifier, state, user_id} in provider_oauth_pending
+    Backend-->>Browser: 302 Redirect to claude.ai/oauth/authorize
+    Note over Browser,Anthropic: Params: client_id, code_challenge,<br/>redirect_uri (localhost:54545), scopes
+
+    Browser->>Anthropic: Authorization request
+    User->>Anthropic: Consent + authorize
+    Anthropic-->>Browser: Redirect to localhost callback with code + state
+
+    Browser->>Backend: Callback with code + state
+    Backend->>Backend: Verify state matches provider_oauth_pending
+    Backend->>Anthropic: POST /v1/oauth/token (code + code_verifier)
+    Anthropic-->>Backend: {access_token, refresh_token, expires_in}
+
+    Backend->>Backend: Store tokens in user_provider_tokens
+    Backend-->>Browser: Success response
+```
+
+The `TokenExchanger` trait abstracts the token exchange, making it mockable for tests. Provider OAuth pending states are stored separately from Google SSO in `provider_oauth_pending: Arc<DashMap<String, ProviderOAuthPendingState>>`.
+
+### OpenAI and Gemini (API Key Storage)
+
+OpenAI and Gemini use simple API key authentication — no OAuth flow required. Users enter their API key in the web UI, and it's stored directly in the `user_provider_tokens` table. The key is used as-is in the `Authorization: Bearer {key}` header when making requests to the provider API.
+
+---
+
 ## Setup-Only Mode
 
 On first run (no admin user in DB), the gateway enters setup-only mode:
@@ -370,22 +539,30 @@ flowchart LR
         APIKEYS["api_keys.rs<br/><i>Per-user API key CRUD</i>"]
         USERKIRO["user_kiro.rs<br/><i>Per-user Kiro token mgmt</i>"]
         USERS["users.rs<br/><i>User admin (admin-only)</i>"]
+        COPILOT["copilot_auth.rs<br/><i>GitHub OAuth → Copilot token</i>"]
+        QWEN["qwen_auth.rs<br/><i>Qwen device flow (RFC 8628)</i>"]
+        PROVIDER_OAUTH["provider_oauth.rs<br/><i>Anthropic PKCE relay,<br/>TokenExchanger trait</i>"]
     end
 
     GOOGLE --> SESSION
     SESSION --> APIKEYS
     SESSION --> USERKIRO
     SESSION --> USERS
+    SESSION --> COPILOT
+    SESSION --> QWEN
+    SESSION --> PROVIDER_OAUTH
 ```
 
 ---
 
 ## How Auth Integrates with the Request Flow
 
-The authentication system touches the request flow at two points:
+The authentication system touches the request flow at three points:
 
-1. **Middleware layer** — The `auth_middleware` SHA-256 hashes the client's API key and looks up the user in cache/DB. If valid, it injects the user's identity and Kiro credentials into the request extensions. This is a fast hash + DashMap lookup, not an OAuth flow.
+1. **Middleware layer** — The `auth_middleware` SHA-256 hashes the client's API key and looks up the user in cache/DB. If valid, it injects the user's identity into the request extensions. This is a fast hash + DashMap lookup, not an OAuth flow.
 
-2. **Handler layer** — Inside `chat_completions_handler` and `anthropic_messages_handler`, the handler retrieves the per-user Kiro access token (from cache or via refresh). This may trigger a background refresh if the token is expiring soon.
+2. **Provider resolution** — The `ProviderRegistry` resolves which provider to use for the request based on the user's configured credentials and priority. It checks its 5-minute credential cache first, then loads from PostgreSQL on cache miss. For OAuth-based providers (Copilot, Qwen, Anthropic), it proactively refreshes tokens nearing expiry using per-provider mutexes to prevent refresh storms.
+
+3. **Handler layer** — For Kiro-bound requests, the handler retrieves the per-user Kiro access token (from cache or via refresh). For direct providers, the `Provider` trait implementation uses the credentials from the registry to call the provider API directly.
 
 The `KiroHttpClient` also holds its own `Arc<AuthManager>` reference for connection-level retry logic. When a request to the Kiro API returns 403, the HTTP client can independently refresh the token and retry without involving the route handler.

--- a/gh-pages/docs/architecture/converters.md
+++ b/gh-pages/docs/architecture/converters.md
@@ -9,7 +9,9 @@ permalink: /architecture/converters/
 # Format Translation System
 {: .no_toc }
 
-The converter modules are the heart of Kiro Gateway's protocol translation capability. They handle bidirectional conversion between OpenAI, Anthropic, and Kiro API formats — covering messages, tool calls, images, system prompts, and streaming events. This page documents the converter architecture, the unified intermediate representation, and field-level mapping details.
+The converter modules handle bidirectional conversion between OpenAI, Anthropic, and Kiro API formats — covering messages, tool calls, images, system prompts, and streaming events. These converters are used when requests are routed to the Kiro provider (the default). When requests are routed to direct providers (Anthropic, OpenAI, Gemini, Copilot, Qwen), the `Provider` trait implementation handles format translation natively, bypassing the converter pipeline.
+
+This page documents the converter architecture, the unified intermediate representation, and field-level mapping details.
 
 ## Table of Contents
 {: .no_toc .text-delta }
@@ -25,18 +27,28 @@ The conversion system uses a hub-and-spoke pattern with a unified intermediate r
 
 ```mermaid
 flowchart LR
-    subgraph Inbound["Inbound (Request)"]
+    subgraph Input["Client Request"]
         OAI_REQ["OpenAI<br/>ChatCompletionRequest"]
         ANT_REQ["Anthropic<br/>AnthropicMessagesRequest"]
     end
 
-    subgraph Unified["Intermediate Representation"]
-        UM["UnifiedMessage[]<br/>+ system prompt<br/>+ tools"]
+    subgraph Routing["Provider Routing"]
+        REGISTRY["ProviderRegistry<br/><i>resolve_provider()</i>"]
     end
 
-    subgraph Kiro["Kiro Wire Format"]
-        KIRO_REQ["Kiro Payload<br/>(generateAssistantResponse)"]
-        KIRO_RESP["Kiro Event Stream<br/>(KiroEvent[])"]
+    subgraph KiroPath["Kiro Path (format conversion)"]
+        subgraph Unified["Intermediate Representation"]
+            UM["UnifiedMessage[]<br/>+ system prompt<br/>+ tools"]
+        end
+
+        subgraph KiroFmt["Kiro Wire Format"]
+            KIRO_REQ["Kiro Payload<br/>(generateAssistantResponse)"]
+            KIRO_RESP["Kiro Event Stream<br/>(KiroEvent[])"]
+        end
+    end
+
+    subgraph DirectPath["Direct Path (passthrough)"]
+        DIRECT["Provider.execute_openai()<br/>Provider.execute_anthropic()<br/><i>Native API relay</i>"]
     end
 
     subgraph Outbound["Outbound (Response)"]
@@ -44,12 +56,20 @@ flowchart LR
         ANT_RESP["Anthropic SSE / JSON"]
     end
 
-    OAI_REQ -->|"openai_to_kiro.rs"| UM
-    ANT_REQ -->|"anthropic_to_kiro.rs"| UM
+    OAI_REQ --> REGISTRY
+    ANT_REQ --> REGISTRY
+    REGISTRY -->|Kiro| UM
+    REGISTRY -->|"Direct provider"| DIRECT
+
+    OAI_REQ -.->|"openai_to_kiro.rs"| UM
+    ANT_REQ -.->|"anthropic_to_kiro.rs"| UM
     UM -->|"core.rs<br/>build_kiro_history()"| KIRO_REQ
 
     KIRO_RESP -->|"kiro_to_openai.rs"| OAI_RESP
     KIRO_RESP -->|"kiro_to_anthropic.rs"| ANT_RESP
+
+    DIRECT --> OAI_RESP
+    DIRECT --> ANT_RESP
 ```
 
 ---

--- a/gh-pages/docs/architecture/index.md
+++ b/gh-pages/docs/architecture/index.md
@@ -9,7 +9,7 @@ permalink: /architecture/
 # Architecture Overview
 {: .no_toc }
 
-Kiro Gateway is a Rust proxy that exposes OpenAI and Anthropic-compatible APIs, translating requests to the Kiro API (AWS CodeWhisperer) backend. It supports two deployment modes:
+Kiro Gateway is a multi-provider AI proxy that exposes OpenAI and Anthropic-compatible APIs. It routes requests to multiple backend providers — Kiro (AWS CodeWhisperer), Anthropic, OpenAI, Gemini, GitHub Copilot, and Qwen — with per-user credential management and automatic provider selection. It supports two deployment modes:
 
 - **Proxy-Only Mode** (`docker-compose.gateway.yml`) — A single backend container with no database, web UI, or TLS. Uses a single `PROXY_API_KEY` for authentication and an AWS SSO device code flow for Kiro credentials. Best for personal use.
 - **Full Deployment** (`docker-compose.yml`) — Four docker-compose services: PostgreSQL database, Rust backend (plain HTTP), nginx frontend (TLS termination + static SPA), and certbot for automated Let's Encrypt certificate management. Supports multi-user with Google SSO and per-user API keys. Best for teams.
@@ -26,7 +26,7 @@ Both modes share the same Rust backend binary — the deployment mode determines
 
 ## High-Level System Diagram
 
-The gateway sits between AI clients (any tool that speaks the OpenAI or Anthropic protocol) and the Kiro/CodeWhisperer backend on AWS. It handles authentication, format translation, streaming, and extended thinking extraction transparently.
+The gateway sits between AI clients (any tool that speaks the OpenAI or Anthropic protocol) and multiple AI provider backends. It handles authentication, multi-provider routing, format translation, streaming, and extended thinking extraction transparently.
 
 ### Full Deployment
 
@@ -72,6 +72,16 @@ flowchart TB
                 MCP["McpManager<br/><i>Tool servers</i>"]
             end
 
+            subgraph Providers["Provider System"]
+                REGISTRY["ProviderRegistry<br/><i>Per-user credential cache (5-min TTL)</i>"]
+                KIRO_P["KiroProvider<br/><i>Default: AWS CodeWhisperer</i>"]
+                ANTHRO_P["AnthropicProvider<br/><i>Direct Anthropic API</i>"]
+                OPENAI_P["OpenAIProvider<br/><i>Direct OpenAI API</i>"]
+                GEMINI_P["GeminiProvider<br/><i>Direct Gemini API</i>"]
+                COPILOT_P["CopilotProvider<br/><i>GitHub Copilot API</i>"]
+                QWEN_P["QwenProvider<br/><i>Qwen Coder API</i>"]
+            end
+
             subgraph Convert["Format Converters"]
                 O2K["openai_to_kiro"]
                 A2K["anthropic_to_kiro"]
@@ -89,7 +99,7 @@ flowchart TB
         end
 
         CERTBOT["certbot<br/><i>Let's Encrypt renewal (12h)</i>"]
-        PG[("PostgreSQL 16<br/><i>Config + Users + API Keys</i>")]
+        PG[("PostgreSQL 16<br/><i>Config + Users + API Keys<br/>+ Provider Tokens</i>")]
     end
 
     subgraph External["External Services"]
@@ -99,6 +109,11 @@ flowchart TB
         GOOGLE["Google OAuth<br/><i>accounts.google.com</i>"]
         BEDROCK["AWS Bedrock<br/><i>bedrock-runtime.{region}.amazonaws.com</i>"]
         EXTERNAL_TOOLS["External MCP<br/>Tool Servers"]
+        ANTHROPIC_API["Anthropic API<br/><i>api.anthropic.com</i>"]
+        OPENAI_API["OpenAI API<br/><i>api.openai.com</i>"]
+        GEMINI_API["Gemini API<br/><i>generativelanguage.googleapis.com</i>"]
+        COPILOT_API["GitHub Copilot API<br/><i>api.githubcopilot.com</i>"]
+        QWEN_API["Qwen API<br/><i>chat.qwen.ai</i>"]
     end
 
     OAI --> Nginx
@@ -111,12 +126,27 @@ flowchart TB
     AUTH --> ANTHRO
     HEALTH -.-> |no auth| CORS
 
-    OPENAI --> O2K
-    ANTHRO --> A2K
+    OPENAI --> REGISTRY
+    ANTHRO --> REGISTRY
+    REGISTRY --> KIRO_P
+    REGISTRY --> ANTHRO_P
+    REGISTRY --> OPENAI_P
+    REGISTRY --> GEMINI_P
+    REGISTRY --> COPILOT_P
+    REGISTRY --> QWEN_P
+
+    KIRO_P --> O2K
+    KIRO_P --> A2K
     O2K --> CORE_C
     A2K --> CORE_C
     CORE_C --> HTTPC
     HTTPC --> KIRO
+
+    ANTHRO_P --> ANTHROPIC_API
+    OPENAI_P --> OPENAI_API
+    GEMINI_P --> GEMINI_API
+    COPILOT_P --> COPILOT_API
+    QWEN_P --> QWEN_API
 
     KIRO --> PARSER
     PARSER --> THINK
@@ -199,8 +229,6 @@ classDiagram
         +ModelResolver resolver
         +Arc~RwLock~Config~~ config
         +Arc~AtomicBool~ setup_complete
-        +Arc~MetricsCollector~ metrics
-        +Arc~Mutex~VecDeque~LogEntry~~~ log_buffer
         +Option~Arc~ConfigDb~~ config_db
         +Arc~DashMap~ session_cache
         +Arc~DashMap~ api_key_cache
@@ -208,6 +236,16 @@ classDiagram
         +Arc~DashMap~ oauth_pending
         +Option~Arc~McpManager~~ mcp_manager
         +Option~Arc~GuardrailsEngine~~ guardrails_engine
+        +Arc~ProviderRegistry~ provider_registry
+        +Arc~AnthropicProvider~ anthropic_provider
+        +Arc~OpenAIProvider~ openai_provider
+        +Arc~GeminiProvider~ gemini_provider
+        +Arc~CopilotProvider~ copilot_provider
+        +Arc~QwenProvider~ qwen_provider
+        +Arc~DashMap~ provider_oauth_pending
+        +Arc~dyn TokenExchanger~ token_exchanger
+        +Arc~DashMap~ copilot_token_cache
+        +QwenDevicePendingMap qwen_device_pending
     }
 
     class ModelCache {
@@ -252,11 +290,19 @@ classDiagram
         +bool truncation_recovery
     }
 
+    class ProviderRegistry {
+        +Arc~DashMap~ cache
+        +Arc~RefreshLockMap~ refresh_locks
+        +resolve_provider(user_id, model, config_db, token_exchanger) ProviderCredentials
+        +evict_user(user_id)
+    }
+
     AppState --> ModelCache
     AppState --> AuthManager
     AppState --> KiroHttpClient
     AppState --> ModelResolver
     AppState --> Config
+    AppState --> ProviderRegistry
     ModelResolver --> ModelCache
     KiroHttpClient --> AuthManager
 ```
@@ -271,6 +317,10 @@ Key design decisions for AppState:
 - `api_key_cache` maps SHA-256 hashed API keys to `(user_id, key_id)` tuples for fast per-user auth lookup.
 - `kiro_token_cache` stores per-user Kiro access tokens with a 4-minute TTL.
 - `oauth_pending` stores PKCE state during OAuth flows with a 10-minute TTL and 10k capacity cap.
+- `provider_registry` resolves which provider (Kiro, Anthropic, OpenAI, Gemini, Copilot, Qwen) to use for a given user + model, with a 5-minute credential cache and proactive token refresh.
+- `provider_oauth_pending` stores PKCE state for provider OAuth relay flows (Anthropic), separate from Google SSO's `oauth_pending`.
+- `copilot_token_cache` stores per-user Copilot API tokens with base URL and timestamp.
+- `qwen_device_pending` stores in-progress Qwen device flow states (device_code → pending state).
 
 ---
 
@@ -292,6 +342,7 @@ flowchart TD
     MAIN --> LOGCAP["log_capture"]
     MAIN --> GUARDRAILS["guardrails/"]
     MAIN --> MCP["mcp/"]
+    MAIN --> PROVIDERS["providers/"]
 
     ROUTES --> CONVERTERS["converters/"]
     ROUTES --> STREAMING["streaming/"]
@@ -305,6 +356,10 @@ flowchart TD
     ROUTES --> METRICS
     ROUTES --> GUARDRAILS
     ROUTES --> MCP
+    ROUTES --> PROVIDERS
+
+    PROVIDERS --> WEBUI
+    PROVIDERS --> HTTPC
 
     STREAMING --> THINK["thinking_parser"]
     STREAMING --> TRUNC
@@ -348,9 +403,9 @@ flowchart TD
 
 ## Design Principles
 
-### 1. Protocol Translation, Not Reimplementation
+### 1. Multi-Provider Protocol Translation
 
-The gateway does not implement its own LLM logic. It is a pure protocol translator: it accepts requests in OpenAI or Anthropic format, converts them to the Kiro wire format, and converts responses back. The `converters/core.rs` module defines a `UnifiedMessage` type that serves as the intermediate representation between all three formats.
+The gateway does not implement its own LLM logic. It is a protocol translator and provider router: it accepts requests in OpenAI or Anthropic format, resolves the target provider via the `ProviderRegistry`, and either translates to the Kiro wire format (for the default Kiro provider) or relays directly to the provider's native API (Anthropic, OpenAI, Gemini, Copilot, Qwen). The `Provider` trait (`providers/traits.rs`) defines a uniform interface that all providers implement, supporting both OpenAI-format and Anthropic-format inputs. The `converters/core.rs` module defines a `UnifiedMessage` type that serves as the intermediate representation for Kiro-bound requests.
 
 ### 2. TLS at the Edge
 
@@ -407,4 +462,8 @@ Datadog APM is zero-overhead when not configured. When `DD_AGENT_HOST` is set, t
 | `backend/src/log_capture.rs` | Tracing capture layer for web UI SSE log streaming |
 | `backend/src/guardrails/` | Content validation: CEL rule engine, AWS Bedrock guardrails, profiles/rules CRUD |
 | `backend/src/mcp/` | MCP Gateway: tool server connections (HTTP/SSE/STDIO), tool discovery, execution, JSON-RPC server |
+| `backend/src/providers/` | Multi-provider system: `Provider` trait, `ProviderRegistry` (credential cache + routing), implementations for Kiro, Anthropic, OpenAI, Gemini, Copilot, Qwen |
 | `backend/src/web_ui/` | Web UI API: Google SSO, sessions, per-user API keys, Kiro tokens, config, users |
+| `backend/src/web_ui/copilot_auth.rs` | GitHub Copilot OAuth flow (GitHub OAuth → Copilot token exchange) |
+| `backend/src/web_ui/qwen_auth.rs` | Qwen Coder device flow (RFC 8628) |
+| `backend/src/web_ui/provider_oauth.rs` | Provider OAuth relay (Anthropic PKCE flow, token exchange trait) |

--- a/gh-pages/docs/architecture/request-flow.md
+++ b/gh-pages/docs/architecture/request-flow.md
@@ -35,12 +35,14 @@ sequenceDiagram
     participant GuardrailEngine as Guardrails Engine
     participant McpMgr as MCP Manager
     participant Resolver as Model Resolver
+    participant Registry as ProviderRegistry
     participant Converter as Converter
     participant TokenCount as Tokenizer
     participant Truncation as Truncation Recovery
     participant AuthMgr as AuthManager
     participant HTTP as KiroHttpClient
     participant KiroAPI as Kiro API
+    participant DirectAPI as Direct Provider API
     participant StreamParser as Stream Parser
     participant ThinkParser as Thinking Parser
     participant OutConverter as Output Converter
@@ -84,65 +86,85 @@ sequenceDiagram
     Resolver->>Resolver: Normalize → check hidden models → check cache
     Resolver-->>Handler: ModelResolution {internal_id, source, is_verified}
 
+    Handler->>Registry: resolve_provider(user_id, model, config_db)
+    Registry->>Registry: Check credential cache (5-min TTL)
+    alt Cache miss
+        Registry->>Registry: Load user provider tokens from DB
+        Registry->>Registry: Select provider by priority + model match
+    end
+    Registry-->>Handler: ProviderCredentials {provider, access_token, base_url}
+
     opt MCP enabled
         Handler->>McpMgr: get_available_tools(request_headers)
         McpMgr-->>Handler: MCP tools (namespaced as clientName_toolName)
         Handler->>Handler: Inject MCP tools into request tool list
     end
 
-    Handler->>Truncation: Inject recovery messages (if enabled)
-    Handler->>Converter: Convert to Kiro format
-    Converter->>Converter: Extract system prompt
-    Converter->>Converter: Convert messages to UnifiedMessage
-    Converter->>Converter: Convert tools (if any)
-    Converter->>Converter: Build Kiro payload JSON
-    Converter-->>Handler: KiroPayload
+    alt Kiro provider (default)
+        Handler->>Truncation: Inject recovery messages (if enabled)
+        Handler->>Converter: Convert to Kiro format
+        Converter->>Converter: Extract system prompt
+        Converter->>Converter: Convert messages to UnifiedMessage
+        Converter->>Converter: Convert tools (if any)
+        Converter->>Converter: Build Kiro payload JSON
+        Converter-->>Handler: KiroPayload
 
-    Handler->>TokenCount: Count input tokens
-    Handler->>AuthMgr: Get per-user access token
-    AuthMgr->>AuthMgr: Check kiro_token_cache (4-min TTL)
-    alt Token expired or missing
-        AuthMgr->>AuthMgr: refresh_aws_sso_oidc()
-    end
-    AuthMgr-->>Handler: Valid access token
-
-    Handler->>HTTP: POST /generateAssistantResponse
-    HTTP->>KiroAPI: Send request with Bearer token
-    alt HTTP error (429, 5xx)
-        HTTP->>HTTP: Exponential backoff + retry
-    end
-    alt 403 Forbidden
-        HTTP->>AuthMgr: Refresh token
-        HTTP->>KiroAPI: Retry with new token
-    end
-    KiroAPI-->>HTTP: AWS Event Stream response
-
-    alt Streaming mode
-        loop For each binary frame
-            HTTP-->>StreamParser: Stream chunk
-            StreamParser->>StreamParser: Parse AWS Event Stream binary
-            StreamParser->>StreamParser: Extract assistantResponseEvent JSON
-            StreamParser->>ThinkParser: Feed content to thinking FSM
-            ThinkParser-->>StreamParser: ThinkingParseResult
-            StreamParser->>OutConverter: Convert KiroEvent to target format
-            OutConverter-->>SSE: Format as SSE event
-            SSE-->>Client: data: {...}\n\n
+        Handler->>TokenCount: Count input tokens
+        Handler->>AuthMgr: Get per-user access token
+        AuthMgr->>AuthMgr: Check kiro_token_cache (4-min TTL)
+        alt Token expired or missing
+            AuthMgr->>AuthMgr: refresh_aws_sso_oidc()
         end
-        SSE-->>Client: data: [DONE] or event: message_stop
-    else Non-streaming mode
-        StreamParser->>StreamParser: Collect all events
-        StreamParser->>OutConverter: Build complete response JSON
-        opt Guardrails enabled (output, non-streaming only)
-            OutConverter->>GuardrailEngine: validate_output(assistant_content, RequestContext)
-            alt Content blocked
-                GuardrailEngine-->>Client: 403 Guardrail Blocked
-            else Content redacted
-                GuardrailEngine-->>OutConverter: GuardrailWarning (redacted content)
-            else Content passed
-                GuardrailEngine-->>OutConverter: OK
+        AuthMgr-->>Handler: Valid access token
+
+        Handler->>HTTP: POST /generateAssistantResponse
+        HTTP->>KiroAPI: Send request with Bearer token
+        alt HTTP error (429, 5xx)
+            HTTP->>HTTP: Exponential backoff + retry
+        end
+        alt 403 Forbidden
+            HTTP->>AuthMgr: Refresh token
+            HTTP->>KiroAPI: Retry with new token
+        end
+        KiroAPI-->>HTTP: AWS Event Stream response
+
+        alt Streaming mode
+            loop For each binary frame
+                HTTP-->>StreamParser: Stream chunk
+                StreamParser->>StreamParser: Parse AWS Event Stream binary
+                StreamParser->>StreamParser: Extract assistantResponseEvent JSON
+                StreamParser->>ThinkParser: Feed content to thinking FSM
+                ThinkParser-->>StreamParser: ThinkingParseResult
+                StreamParser->>OutConverter: Convert KiroEvent to target format
+                OutConverter-->>SSE: Format as SSE event
+                SSE-->>Client: data: {...}\n\n
             end
+            SSE-->>Client: data: [DONE] or event: message_stop
+        else Non-streaming mode
+            StreamParser->>StreamParser: Collect all events
+            StreamParser->>OutConverter: Build complete response JSON
+            opt Guardrails enabled (output, non-streaming only)
+                OutConverter->>GuardrailEngine: validate_output(assistant_content, RequestContext)
+                alt Content blocked
+                    GuardrailEngine-->>Client: 403 Guardrail Blocked
+                else Content redacted
+                    GuardrailEngine-->>OutConverter: GuardrailWarning (redacted content)
+                else Content passed
+                    GuardrailEngine-->>OutConverter: OK
+                end
+            end
+            OutConverter-->>Client: Single JSON response
         end
-        OutConverter-->>Client: Single JSON response
+
+    else Direct provider (Anthropic, OpenAI, Gemini, Copilot, Qwen)
+        Handler->>DirectAPI: Relay request with provider credentials
+        alt Streaming mode
+            DirectAPI-->>SSE: Provider SSE stream
+            SSE-->>Client: Passthrough SSE events
+        else Non-streaming mode
+            DirectAPI-->>Handler: JSON response
+            Handler-->>Client: Relay JSON response
+        end
     end
 ```
 
@@ -220,6 +242,36 @@ flowchart LR
 ```
 
 The resolution result includes the `source` field (`"hidden"`, `"cache"`, or `"passthrough"`) and an `is_verified` flag indicating whether the model was found in a known list.
+
+### Step 6.5: Provider Resolution
+
+The `ProviderRegistry` (`backend/src/providers/registry.rs`) determines which AI provider handles the request based on the user's configured credentials and provider priority:
+
+```mermaid
+flowchart TD
+    REQ["User ID + Model"] --> CACHE_CHECK{"Credential cache<br/>(5-min TTL)?"}
+    CACHE_CHECK -->|Hit| RESOLVE["Select provider by priority"]
+    CACHE_CHECK -->|Miss| LOAD["Load user_provider_tokens from DB"]
+    LOAD --> EXPIRY{"Token expiring<br/>within 5 min?"}
+    EXPIRY -->|Yes| REFRESH["Proactive token refresh<br/>(per-provider mutex)"]
+    REFRESH --> CACHE_STORE["Store in credential cache"]
+    EXPIRY -->|No| CACHE_STORE
+    CACHE_STORE --> RESOLVE
+    RESOLVE --> RESULT["ProviderCredentials<br/>{provider, access_token, base_url}"]
+```
+
+Each user can configure multiple providers with priority ordering. The registry selects the highest-priority provider that has valid credentials. Supported providers:
+
+| Provider | Auth Method | API Endpoint |
+|----------|-----------|-------------|
+| Kiro (default) | AWS SSO OIDC refresh token | `codewhisperer.{region}.amazonaws.com` |
+| Anthropic | OAuth PKCE relay | `api.anthropic.com` |
+| OpenAI | API key (stored) | `api.openai.com` |
+| Gemini | API key (stored) | `generativelanguage.googleapis.com` |
+| Copilot | GitHub OAuth → Copilot token | `api.githubcopilot.com` |
+| Qwen | Device flow (RFC 8628) | `chat.qwen.ai` |
+
+For the Kiro provider, the request continues through the format conversion and streaming pipeline. For direct providers (Anthropic, OpenAI, Gemini, Copilot, Qwen), the `Provider` trait implementation handles the request natively — relaying it to the provider's API and streaming the response back to the client.
 
 ### Step 7: Truncation Recovery Injection
 

--- a/gh-pages/docs/architecture/streaming.md
+++ b/gh-pages/docs/architecture/streaming.md
@@ -11,6 +11,9 @@ permalink: /architecture/streaming/
 
 The Kiro API returns all responses — streaming and non-streaming — in AWS Event Stream binary format. This page covers how the gateway parses that binary protocol, extracts meaningful events, processes thinking blocks, detects truncation, and formats the output as Server-Sent Events (SSE) for OpenAI and Anthropic clients.
 
+This streaming pipeline is specific to the Kiro provider path. When requests are routed to direct providers (Anthropic, OpenAI, Gemini, Copilot, Qwen) via the `ProviderRegistry`, the provider's `stream_openai()` / `stream_anthropic()` trait methods handle streaming natively — the response SSE stream is relayed directly to the client without binary parsing or format conversion.
+{: .note }
+
 ## Table of Contents
 {: .no_toc .text-delta }
 

--- a/gh-pages/docs/configuration.md
+++ b/gh-pages/docs/configuration.md
@@ -47,6 +47,9 @@ Set these in `.env.proxy` and pass via `--env-file .env.proxy` when running `doc
 | `SERVER_PORT` | `8000` | Port the gateway listens on. |
 | `LOG_LEVEL` | `info` | Log verbosity: `debug`, `info`, `warn`, `error`. |
 | `DEBUG_MODE` | `off` | Debug logging: `off`, `errors`, `all`. |
+| `GITHUB_COPILOT_CLIENT_ID` | | GitHub OAuth App Client ID for Copilot provider. |
+| `GITHUB_COPILOT_CLIENT_SECRET` | | GitHub OAuth App Client Secret. |
+| `GITHUB_COPILOT_CALLBACK_URL` | | OAuth callback URL (e.g., `https://{DOMAIN}/_ui/api/copilot/callback`). |
 
 ### Builder ID vs Identity Center
 
@@ -86,6 +89,15 @@ Set these in your `.env` file before running `docker compose up`. They are read 
 | `GOOGLE_CLIENT_ID` | Google OAuth 2.0 Client ID for Web UI authentication. | `123456.apps.googleusercontent.com` |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth 2.0 Client Secret. | `GOCSPX-abc123` |
 | `GOOGLE_CALLBACK_URL` | OAuth redirect URI. Must match the authorized redirect URI in Google Cloud Console. | `https://gateway.example.com/_ui/api/auth/google/callback` |
+
+### Optional Provider Variables
+
+| Variable | Description | Example |
+|:---|:---|:---|
+| `GITHUB_COPILOT_CLIENT_ID` | GitHub OAuth App Client ID for Copilot provider support. | `Iv1.abc123` |
+| `GITHUB_COPILOT_CLIENT_SECRET` | GitHub OAuth App Client Secret. | `secret_abc123` |
+| `GITHUB_COPILOT_CALLBACK_URL` | Copilot OAuth callback URL. | `https://gateway.example.com/_ui/api/copilot/callback` |
+| `QWEN_OAUTH_CLIENT_ID` | Qwen Coder OAuth client ID (device flow, no secret required). Default public ID: `f0304373b74a44d2b584a3fb70ca9e56`. | `f0304373b74a44d2b584a3fb70ca9e56` |
 
 ### Auto-managed by docker-compose
 
@@ -240,6 +252,14 @@ POSTGRES_PASSWORD=change-me-to-something-strong
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 GOOGLE_CALLBACK_URL=https://gateway.example.com/_ui/api/auth/google/callback
+
+# GitHub Copilot OAuth (optional)
+# GITHUB_COPILOT_CLIENT_ID=
+# GITHUB_COPILOT_CLIENT_SECRET=
+# GITHUB_COPILOT_CALLBACK_URL=https://gateway.example.com/_ui/api/copilot/callback
+
+# Qwen Coder OAuth (optional — device flow, no secret required)
+# QWEN_OAUTH_CLIENT_ID=f0304373b74a44d2b584a3fb70ca9e56
 ```
 
 ---

--- a/gh-pages/docs/deployment.md
+++ b/gh-pages/docs/deployment.md
@@ -235,6 +235,14 @@ POSTGRES_PASSWORD=your_secure_password_here
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 GOOGLE_CALLBACK_URL=https://gateway.example.com/_ui/api/auth/google/callback
+
+# GitHub Copilot OAuth (optional)
+# GITHUB_COPILOT_CLIENT_ID=
+# GITHUB_COPILOT_CLIENT_SECRET=
+# GITHUB_COPILOT_CALLBACK_URL=https://gateway.example.com/_ui/api/copilot/callback
+
+# Qwen Coder OAuth (optional — device flow, no secret required)
+# QWEN_OAUTH_CLIENT_ID=f0304373b74a44d2b584a3fb70ca9e56
 ```
 
 The following are managed automatically by `docker-compose.yml` — do **not** set them in `.env`:
@@ -281,7 +289,7 @@ On first launch, the backend starts in **setup-only mode** — the `/v1/*` proxy
 Open `https://your-domain.com/_ui/` and:
 
 1. **Sign in with Google** — the first user is automatically granted the Admin role
-2. **Add Kiro credentials** — authenticate with AWS SSO via the device code flow
+2. **Add provider credentials** — connect Kiro (AWS SSO device code flow), and optionally GitHub Copilot or Qwen Coder on the Profile page
 3. **Create an API key** — generate a personal API key for programmatic access
 
 ## Step 6: Verify
@@ -434,8 +442,13 @@ Tables are created automatically on first connection. Key tables include:
 | `users` | User accounts (Google SSO identity, role, status) |
 | `api_keys` | Per-user API keys (SHA-256 hashed, with labels) |
 | `user_kiro_credentials` | Per-user Kiro refresh tokens |
+| `user_provider_credentials` | Per-user provider credentials (Copilot, Qwen) |
+| `user_provider_priority` | Per-user provider priority ordering |
 | `config` | Key-value configuration store |
 | `config_history` | Audit log of configuration changes |
+| `mcp_clients` | MCP server connections (config, state, encrypted headers) |
+| `guardrail_profiles` | AWS Bedrock guardrail profiles (credentials encrypted) |
+| `guardrail_rules` | Guardrail rules (CEL expressions, sampling, timeouts) |
 
 ### Connection string
 

--- a/gh-pages/docs/getting-started.md
+++ b/gh-pages/docs/getting-started.md
@@ -27,11 +27,14 @@ Key capabilities:
 - Bidirectional format translation (OpenAI/Anthropic to Kiro and back)
 - Streaming responses via Server-Sent Events (SSE)
 - Two deployment modes: **Proxy-Only Mode** (single user) and **Full Deployment** (multi-user)
+- Multi-provider support: Kiro (default), GitHub Copilot, and Qwen Coder — with per-user provider priority
 - Multi-user support with Google SSO and per-user API keys (Full Deployment)
 - Role-based access control (Admin / User)
 - Automatic TLS via Let's Encrypt (certbot + nginx)
 - Web dashboard for configuration, monitoring, and log streaming
-- Per-user Kiro credential management with automatic token refresh
+- Content guardrails via AWS Bedrock with CEL rule engine
+- MCP Gateway for connecting external tool servers
+- Per-user credential management with automatic token refresh
 - Model alias resolution (use familiar model names like `claude-sonnet-4`)
 
 ---
@@ -176,6 +179,14 @@ POSTGRES_PASSWORD=your_secure_password_here
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_CALLBACK_URL=https://gateway.example.com/_ui/api/auth/google/callback
+
+# GitHub Copilot OAuth (optional)
+# GITHUB_COPILOT_CLIENT_ID=
+# GITHUB_COPILOT_CLIENT_SECRET=
+# GITHUB_COPILOT_CALLBACK_URL=https://gateway.example.com/_ui/api/copilot/callback
+
+# Qwen Coder OAuth (optional — device flow, no secret required)
+# QWEN_OAUTH_CLIENT_ID=f0304373b74a44d2b584a3fb70ca9e56
 ```
 
 ### Step 3: Provision TLS certificates
@@ -226,9 +237,15 @@ Navigate to `https://your-domain.com/_ui/` in your browser.
 
 Click **Sign in with Google** to authenticate via Google SSO. The first user to sign in is automatically granted the **Admin** role.
 
-### Step 3: Add Kiro credentials
+### Step 3: Add provider credentials
 
-After signing in, you'll be prompted to add your Kiro (AWS) credentials. The setup wizard guides you through the OAuth device code flow to authenticate with AWS SSO and store a refresh token.
+After signing in, navigate to the **Profile** page to connect your AI provider accounts. The gateway supports multiple providers:
+
+- **Kiro (AWS)** — Default provider. Uses an OAuth device code flow to authenticate with AWS SSO and store a refresh token.
+- **GitHub Copilot** (optional) — Connect via GitHub OAuth. Requires `GITHUB_COPILOT_CLIENT_ID`, `GITHUB_COPILOT_CLIENT_SECRET`, and `GITHUB_COPILOT_CALLBACK_URL` in `.env`.
+- **Qwen Coder** (optional) — Connect via device code flow. Requires `QWEN_OAUTH_CLIENT_ID` in `.env` (a default public client ID is provided).
+
+Each user manages their own provider credentials and can set a priority order for provider fallback.
 
 ### Step 4: Create an API key
 
@@ -263,8 +280,8 @@ sequenceDiagram
     GW->>DB: Create admin user
     GW-->>User: Session cookie — redirect to dashboard
 
-    User->>GW: Add Kiro credentials (device code flow)
-    GW->>DB: Save refresh token
+    User->>GW: Add provider credentials (Kiro, Copilot, Qwen)
+    GW->>DB: Save refresh tokens
 
     User->>GW: Create personal API key
     GW->>DB: Save API key (SHA-256 hashed)
@@ -273,8 +290,8 @@ sequenceDiagram
 
     User->>Nginx: POST /v1/chat/completions
     Nginx->>GW: Proxy (plain HTTP)
-    GW->>GW: Validate API key → find user → get Kiro creds
-    GW->>GW: Convert OpenAI → Kiro format
+    GW->>GW: Validate API key → find user → get provider creds
+    GW->>GW: Convert OpenAI → provider format
     GW-->>User: SSE stream (Kiro → OpenAI format)
 ```
 
@@ -339,11 +356,11 @@ curl -X POST https://your-domain.com/v1/messages \
 
 Open `https://your-domain.com/_ui/` to see:
 
-- Real-time request metrics (latency, token counts)
-- System resource usage
-- Live log viewer
-- Configuration management
-- User and API key management
+- Profile page with provider credential management (Kiro, Copilot, Qwen)
+- Configuration management (admin-only)
+- MCP client management (admin-only)
+- Content guardrails configuration (admin-only)
+- User and API key management (admin-only)
 
 ---
 

--- a/gh-pages/docs/modules.md
+++ b/gh-pages/docs/modules.md
@@ -7,7 +7,7 @@ nav_order: 7
 # Module Reference
 {: .no_toc }
 
-Overview of all source modules in the Kiro Gateway codebase, their responsibilities, and how they interconnect.
+Overview of all source modules in the Kiro Gateway codebase, their responsibilities, and how they interconnect. The gateway supports multiple AI providers (Kiro, Anthropic, OpenAI, Gemini, Copilot, Qwen) via a `Provider` trait and `ProviderRegistry`.
 {: .fs-6 .fw-300 }
 
 <details open markdown="block">
@@ -35,7 +35,7 @@ graph TD
     resolver["resolver.rs<br/><i>Model name aliases</i>"]
     cache["cache.rs<br/><i>Model list cache</i>"]
     metrics["metrics/<br/><i>Request tracking</i>"]
-    web_ui["web_ui/<br/><i>Google SSO, API keys,<br/>sessions, config API</i>"]
+    web_ui["web_ui/<br/><i>Google SSO, API keys,<br/>sessions, config API,<br/>provider OAuth</i>"]
     log_capture["log_capture.rs<br/><i>Tracing → SSE logs</i>"]
     truncation["truncation.rs<br/><i>Truncation recovery</i>"]
     thinking["thinking_parser.rs<br/><i>Reasoning extraction</i>"]
@@ -44,6 +44,7 @@ graph TD
     bench["bench/<br/><i>Benchmarking</i>"]
     guardrails["guardrails/<br/><i>CEL rules + Bedrock<br/>content validation</i>"]
     mcp["mcp/<br/><i>MCP Gateway: tool servers,<br/>JSON-RPC, transports</i>"]
+    providers["providers/<br/><i>Provider trait, registry,<br/>Kiro/Anthropic/OpenAI/<br/>Gemini/Copilot/Qwen</i>"]
 
     main --> config
     main --> routes
@@ -51,6 +52,7 @@ graph TD
     main --> log_capture
     main --> guardrails
     main --> mcp
+    main --> providers
 
     routes --> middleware
     routes --> converters
@@ -63,6 +65,7 @@ graph TD
     routes --> tokenizer
     routes --> guardrails
     routes --> mcp
+    routes --> providers
 
     converters --> models
     converters --> thinking
@@ -82,6 +85,7 @@ graph TD
 
     mcp --> web_ui
     guardrails --> web_ui
+    providers --> web_ui
 
     style main fill:#4a9eff,color:#fff
     style routes fill:#ff6b6b,color:#fff
@@ -93,6 +97,7 @@ graph TD
     style log_capture fill:#ff922b,color:#fff
     style guardrails fill:#e64980,color:#fff
     style mcp fill:#20c997,color:#fff
+    style providers fill:#339af0,color:#fff
 ```
 
 ---
@@ -184,6 +189,9 @@ graph TD
 | `web_ui::config_api` | `backend/src/web_ui/config_api.rs` | Config field validation and metadata. `classify_config_change()` determines if a field change can be hot-reloaded or requires restart. `validate_config_field()` validates types and ranges. `get_config_field_descriptions()` provides human-readable descriptions for the config UI. |
 | `web_ui::config_db` | `backend/src/web_ui/config_db.rs` | `ConfigDb` — PostgreSQL-backed configuration persistence using `sqlx`. Auto-creates `config`, `config_history`, and `schema_version` tables. Provides `get/set/get_all`, `load_into_config()` overlay, `save_initial_setup()`, `save_oauth_setup()`, and `get_history()` with automatic pruning (keeps last 1000 entries). All writes are transactional. |
 | `web_ui::sse` | `backend/src/web_ui/sse.rs` | Server-Sent Event streams for the Web UI. `metrics_stream` pushes metrics snapshots every 1 second. `logs_stream` pushes new log entries every 500ms. Both include 15-second keep-alive pings. |
+| `web_ui::copilot_auth` | `backend/src/web_ui/copilot_auth.rs` | GitHub Copilot OAuth flow. Two-step process: GitHub OAuth for user authorization, then Copilot-specific token exchange via `copilot_internal/v2/token`. Stores Copilot token + base URL in DB and `copilot_token_cache`. |
+| `web_ui::qwen_auth` | `backend/src/web_ui/qwen_auth.rs` | Qwen Coder device flow (RFC 8628). Endpoints for initiating device authorization, polling for token, checking status, and disconnecting. Uses `qwen_device_pending` DashMap for in-flight flows (10-min TTL, 10k cap). |
+| `web_ui::provider_oauth` | `backend/src/web_ui/provider_oauth.rs` | Provider OAuth relay for Anthropic (PKCE flow). Defines `TokenExchanger` trait (mockable for tests), `ProviderOAuthPendingState`, and OAuth config per provider. Handles authorization redirect, code exchange, and token storage in `user_provider_tokens`. |
 
 ### Guardrails
 
@@ -196,6 +204,21 @@ graph TD
 | `guardrails::db` | `backend/src/guardrails/db.rs` | `GuardrailsDb` — PostgreSQL layer for guardrail profiles and rules. Three tables: `guardrail_profiles`, `guardrail_rules`, `guardrail_rule_profiles` (junction). CRUD operations + `load_config()` for in-memory snapshot. |
 | `guardrails::api` | `backend/src/guardrails/api.rs` | Admin API handlers for guardrail profiles and rules CRUD. Includes test endpoint for validating a profile against Bedrock and CEL expression validation endpoint. All admin-only with session + CSRF. |
 | `guardrails::types` | `backend/src/guardrails/types.rs` | Type definitions: `GuardrailRule`, `GuardrailProfile`, `GuardrailAction` (None/Intervened/Redacted), `ApplyTo` (Input/Output/Both), `RequestContext`, `GuardrailViolation`, `GuardrailCheckResult`. |
+
+### Providers
+
+| Module | File(s) | Description |
+|--------|---------|-------------|
+| `providers` | `backend/src/providers/mod.rs` | Module root. Re-exports all provider implementations, the registry, trait, and types. |
+| `providers::traits` | `backend/src/providers/traits.rs` | `Provider` trait — the uniform interface all AI providers implement. Defines `execute_openai()`, `stream_openai()`, `execute_anthropic()`, `stream_anthropic()` methods. Each provider handles both OpenAI-format and Anthropic-format inputs. |
+| `providers::types` | `backend/src/providers/types.rs` | Type definitions: `ProviderId` enum (Kiro, Anthropic, OpenAI, Gemini, Copilot, Qwen), `ProviderCredentials` (provider + access_token + optional base_url), `ProviderContext` (per-request credentials + model), `ProviderResponse`, `ProviderStreamItem`. |
+| `providers::registry` | `backend/src/providers/registry.rs` | `ProviderRegistry` — resolves which provider to use for a given user + model. Caches per-user provider credentials in memory (5-minute TTL). Handles transparent token refresh for OAuth-based providers with per-(user, provider) mutexes to prevent refresh storms. |
+| `providers::kiro` | `backend/src/providers/kiro.rs` | Kiro provider — the default. Routes requests through the format converter pipeline (OpenAI/Anthropic → Kiro) and streaming pipeline (AWS Event Stream → SSE). Uses `KiroHttpClient` and `AuthManager` for token management. |
+| `providers::anthropic` | `backend/src/providers/anthropic.rs` | Anthropic provider — direct relay to `api.anthropic.com`. Passes OpenAI-format requests through conversion, relays Anthropic-format requests natively. |
+| `providers::openai` | `backend/src/providers/openai.rs` | OpenAI provider — direct relay to `api.openai.com`. Relays OpenAI-format requests natively, converts Anthropic-format requests. |
+| `providers::gemini` | `backend/src/providers/gemini.rs` | Gemini provider — direct relay to `generativelanguage.googleapis.com`. Handles format conversion for both OpenAI and Anthropic inputs. |
+| `providers::copilot` | `backend/src/providers/copilot.rs` | Copilot provider — relay to GitHub Copilot API. Uses Copilot-specific headers (Editor-Version, Editor-Plugin-Version, Copilot-Integration-Id). Base URL from token exchange (may vary for enterprise). |
+| `providers::qwen` | `backend/src/providers/qwen.rs` | Qwen provider — relay to `chat.qwen.ai`. Handles Qwen-specific API format and authentication. |
 
 ### MCP Gateway
 
@@ -254,6 +277,16 @@ All request handlers receive shared application state via Axum's `State` extract
 - `oauth_pending: Arc<DashMap<String, OAuthPendingState>>` — PKCE state (10-min TTL, 10k cap)
 - `mcp_manager: Option<Arc<McpManager>>` — MCP Gateway orchestrator (None when disabled or not yet initialized)
 - `guardrails_engine: Option<Arc<GuardrailsEngine>>` — Content validation engine (None when disabled or no DB)
+- `provider_registry: Arc<ProviderRegistry>` — resolves provider + credentials per user/model (5-min credential cache)
+- `anthropic_provider: Arc<AnthropicProvider>` — direct Anthropic API provider
+- `openai_provider: Arc<OpenAIProvider>` — direct OpenAI API provider
+- `gemini_provider: Arc<GeminiProvider>` — direct Gemini API provider
+- `copilot_provider: Arc<CopilotProvider>` — direct GitHub Copilot API provider
+- `qwen_provider: Arc<QwenProvider>` — direct Qwen Coder API provider
+- `provider_oauth_pending: Arc<DashMap<String, ProviderOAuthPendingState>>` — PKCE state for provider OAuth relay (separate from Google SSO)
+- `token_exchanger: Arc<dyn TokenExchanger>` — OAuth token exchange abstraction (mockable for tests)
+- `copilot_token_cache: Arc<DashMap<Uuid, (String, String, Instant)>>` — per-user Copilot tokens (token, base_url, cached_at)
+- `qwen_device_pending: QwenDevicePendingMap` — pending Qwen device flow states (10-min TTL, 10k cap)
 
 ### Request Guard
 

--- a/gh-pages/docs/quickstart.md
+++ b/gh-pages/docs/quickstart.md
@@ -99,6 +99,14 @@ POSTGRES_PASSWORD=change-me
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 GOOGLE_CALLBACK_URL=https://gateway.example.com/_ui/api/auth/google/callback
+
+# Optional: GitHub Copilot OAuth
+# GITHUB_COPILOT_CLIENT_ID=
+# GITHUB_COPILOT_CLIENT_SECRET=
+# GITHUB_COPILOT_CALLBACK_URL=https://gateway.example.com/_ui/api/copilot/callback
+
+# Optional: Qwen Coder (device flow)
+# QWEN_OAUTH_CLIENT_ID=f0304373b74a44d2b584a3fb70ca9e56
 ```
 
 You need a **Google OAuth Client ID** from the [Google Cloud Console](https://console.cloud.google.com/apis/credentials) with the redirect URI set to your callback URL above.
@@ -138,7 +146,7 @@ Server listening on http://0.0.0.0:8000
 Open `https://your-domain.com/_ui/` in your browser.
 
 1. Click **Sign in with Google** — the first user gets the Admin role
-2. Add your **Kiro credentials** via the AWS SSO device code flow
+2. Connect your **provider credentials** on the Profile page (Kiro via AWS SSO device code flow, optionally GitHub Copilot or Qwen Coder)
 3. Create a **personal API key** in the API Keys section
 
 ### 5. Verify it works

--- a/gh-pages/docs/research-notes.md
+++ b/gh-pages/docs/research-notes.md
@@ -143,3 +143,42 @@ When the probe can't determine the output cap empirically, use Anthropic's docum
 
 - The binary search uses character count as a proxy for tokens (~4 chars/token). The reported token count comes from the gateway's tiktoken estimate, not Kiro's tokenizer directly.
 - The `auto` model is skipped by default since it's a routing alias, not a real model with its own limits.
+
+---
+
+## Multi-Provider Architecture
+
+### Summary
+
+As of v1.0.8, the gateway supports multiple AI providers beyond the original Kiro (AWS CodeWhisperer) backend. Each user can connect credentials for multiple providers and set a priority order for fallback.
+
+### Supported Providers
+
+| Provider | Auth Method | Env Vars Required | Notes |
+|---|---|---|---|
+| **Kiro** (default) | AWS SSO device code flow | None (built-in) | Original provider, always available |
+| **GitHub Copilot** | GitHub OAuth (authorization code) | `GITHUB_COPILOT_CLIENT_ID`, `GITHUB_COPILOT_CLIENT_SECRET`, `GITHUB_COPILOT_CALLBACK_URL` | Requires a registered GitHub OAuth App |
+| **Qwen Coder** | Device code flow | `QWEN_OAUTH_CLIENT_ID` (optional, default public ID provided) | No client secret required |
+
+### Architecture Decisions
+
+**Per-user provider credentials.** Each user manages their own provider connections via the Profile page. Credentials are stored encrypted in PostgreSQL and cached in memory with TTL-based refresh.
+
+**Provider priority.** Users set a priority order (e.g., Kiro > Copilot > Qwen). When a request arrives, the gateway resolves the user's highest-priority provider with valid credentials and routes the request there. If the top provider fails, it does not automatically fall back mid-request — the user must adjust priority or fix credentials.
+
+**Provider registry pattern.** Providers are registered in `backend/src/providers/registry.rs` using a `ProviderRegistry`. Each provider implements a common trait for credential resolution and request proxying. Adding a new provider requires implementing the trait and registering it.
+
+**OAuth relay for Copilot.** The Copilot OAuth flow uses a relay pattern: the backend initiates the GitHub OAuth redirect, and the callback is handled at `/_ui/api/copilot/callback`. The relay token mechanism (`provider_oauth.rs`) securely bridges the OAuth flow between the browser and backend.
+
+**Device code flow for Qwen.** Similar to the Kiro device code flow, Qwen uses a polling-based device authorization. The frontend polls `/_ui/api/qwen/poll` until the user completes authorization in their browser.
+
+### Impact on Request Flow
+
+The request flow now includes a provider resolution step:
+
+1. API key auth → resolve user
+2. Check user's provider priority list
+3. Get credentials for highest-priority available provider
+4. Convert request to provider's format (Kiro, Copilot, or Qwen)
+5. Proxy to provider API
+6. Convert response back to OpenAI/Anthropic format

--- a/gh-pages/docs/troubleshooting.md
+++ b/gh-pages/docs/troubleshooting.md
@@ -500,6 +500,85 @@ docker compose -f docker-compose.gateway.yml --env-file .env.proxy restart gatew
 
 ---
 
+## Provider-Specific Issues
+
+### GitHub Copilot
+
+#### "Copilot not available" or connect button missing
+
+**Cause:** The Copilot provider is not configured on the server.
+
+**Solutions:**
+- Verify `GITHUB_COPILOT_CLIENT_ID`, `GITHUB_COPILOT_CLIENT_SECRET`, and `GITHUB_COPILOT_CALLBACK_URL` are set in `.env`
+- The callback URL must be `https://{DOMAIN}/_ui/api/copilot/callback`
+- Register a GitHub OAuth App at [GitHub Developer Settings](https://github.com/settings/developers) with the matching callback URL
+- Restart the backend after changing environment variables
+
+#### Copilot token refresh fails
+
+**Cause:** The GitHub OAuth refresh token has expired or been revoked.
+
+**Solutions:**
+- Go to the Profile page in the Web UI and disconnect Copilot, then reconnect
+- Check that the GitHub OAuth App is still active and not suspended
+- Verify the user hasn't revoked the app's access in their GitHub settings (Settings > Applications > Authorized OAuth Apps)
+
+#### "Failed to exchange code" during Copilot connect
+
+**Cause:** The OAuth code exchange with GitHub failed.
+
+**Solutions:**
+- Verify `GITHUB_COPILOT_CLIENT_SECRET` is correct
+- Check that the callback URL in `.env` exactly matches the one registered in the GitHub OAuth App
+- Check backend logs for the specific error: `docker compose logs backend | grep -i copilot`
+
+### Qwen Coder
+
+#### Qwen device flow not starting
+
+**Cause:** The Qwen OAuth client ID is not configured.
+
+**Solutions:**
+- Set `QWEN_OAUTH_CLIENT_ID` in `.env` (default public client ID: `f0304373b74a44d2b584a3fb70ca9e56`)
+- Restart the backend after changing environment variables
+
+#### Qwen rate limiting (429 errors)
+
+**Cause:** The Qwen API has rate limits that may be stricter than Kiro's.
+
+**Solutions:**
+- Reduce request frequency to the Qwen provider
+- Set provider priority in the Profile page to prefer Kiro or Copilot for high-traffic use
+- Check if the Qwen account tier has higher rate limits available
+
+#### Qwen device code expired
+
+**Cause:** The device code flow timed out before the user authorized in the browser.
+
+**Solution:** Go to the Profile page, disconnect Qwen, and start the connect flow again. Complete the browser authorization promptly when the device code URL appears.
+
+### Provider Priority and Fallback
+
+#### Requests using wrong provider
+
+**Cause:** Provider priority order may not be set as expected.
+
+**Solutions:**
+- Check the Profile page to verify your provider priority order
+- The gateway uses the first available provider in priority order — if a higher-priority provider's credentials are expired, it falls back to the next
+- Reconnect any providers showing as disconnected
+
+#### "No provider credentials available"
+
+**Cause:** None of the user's configured providers have valid credentials.
+
+**Solutions:**
+- Go to the Profile page and check the status of each connected provider
+- Reconnect any providers with expired tokens
+- Ensure at least one provider (Kiro, Copilot, or Qwen) is connected and active
+
+---
+
 ## Datadog APM Issues
 
 ### No traces appearing in Datadog

--- a/gh-pages/docs/web-ui.md
+++ b/gh-pages/docs/web-ui.md
@@ -17,19 +17,18 @@ The frontend is a React 19 SPA built with Vite and TypeScript, served as static 
 ```mermaid
 flowchart TB
     subgraph Browser["Browser (React SPA)"]
-        Setup[Setup Wizard]
+        Login[Login Page]
+        Profile[Profile Page]
         Config[Config Manager]
-        Metrics[Metrics Dashboard]
-        Logs[Log Viewer]
-        Users[User Management]
-        Keys[API Key Management]
+        Admin[Admin Panel]
+        Guardrails[Guardrails Config]
+        MCP[MCP Client Manager]
     end
 
     subgraph Nginx["nginx (:443/:80)"]
         Static["/_ui/* → static files"]
         Proxy["/_ui/api/* → backend:8000"]
         ProxyV1["/v1/* → backend:8000"]
-        Certbot["/.well-known/ → certbot"]
     end
 
     subgraph Backend["Rust Backend (plain HTTP :8000)"]
@@ -39,34 +38,40 @@ flowchart TB
             GoogleCB[GET /auth/google/callback]
         end
         subgraph SessionAPI["Session-Authenticated API"]
-            MetricsAPI[GET /metrics]
-            SystemAPI[GET /system]
-            ModelsAPI[GET /models]
-            LogsAPI[GET /logs]
+            AuthMe[GET /auth/me]
             ConfigRead[GET /config]
             SchemaAPI[GET /config/schema]
-            HistoryAPI[GET /config/history]
-            AuthMe[GET /auth/me]
-            StreamMetrics[SSE /stream/metrics]
-            StreamLogs[SSE /stream/logs]
+            SystemAPI[GET /system]
+            ModelsAPI[GET /models]
+            KiroRoutes[Kiro token mgmt]
+            KeyRoutes[API key mgmt]
+            CopilotRoutes[Copilot OAuth]
+            QwenRoutes[Qwen device flow]
+            ProviderPriority[Provider priority]
         end
         subgraph AdminAPI["Admin API (+ CSRF)"]
             ConfigWrite[PUT /config]
             UserMgmt[User Management]
             DomainAllow[Domain Allowlist]
+            MCPAdmin[MCP client CRUD]
+            GuardrailsAdmin[Guardrails CRUD]
         end
     end
 
     Browser -->|HTTPS| Nginx
     Static --> Browser
     Proxy --> Backend
-    Setup --> GoogleAuth
+    Login --> GoogleAuth
+    Profile --> KiroRoutes
+    Profile --> CopilotRoutes
+    Profile --> QwenRoutes
+    Profile --> ProviderPriority
+    Profile --> KeyRoutes
     Config --> ConfigRead
     Config --> ConfigWrite
-    Metrics --> StreamMetrics
-    Logs --> StreamLogs
-    Users --> UserMgmt
-    Keys -->|"API Key CRUD"| SessionAPI
+    Admin --> UserMgmt
+    MCP --> MCPAdmin
+    Guardrails --> GuardrailsAdmin
 ```
 
 ---
@@ -113,6 +118,61 @@ The first user to complete Google SSO setup is automatically assigned the **Admi
 - CSRF token: separate cookie, required for all mutation endpoints (POST, PUT, DELETE)
 - Use `GET /_ui/api/auth/me` to check current session status and user info
 - Use `POST /_ui/api/auth/logout` to end the session
+
+---
+
+## Pages
+
+The Web UI is organized into the following pages, accessible via the sidebar navigation:
+
+### Profile (`/_ui/profile`)
+
+The default landing page after login. Each user manages their own credentials and settings here:
+
+- **Provider Credentials** — Connect and manage AI provider accounts:
+  - **Kiro (AWS)** — Connect via AWS SSO device code flow. Shows connection status and allows disconnect/reconnect.
+  - **GitHub Copilot** — Connect via GitHub OAuth (only available if `GITHUB_COPILOT_CLIENT_ID` is configured server-side). Shows connection status.
+  - **Qwen Coder** — Connect via device code flow (only available if `QWEN_OAUTH_CLIENT_ID` is configured). Shows device code URL for browser authorization.
+- **Provider Priority** — Drag-and-drop reordering of provider fallback priority. The gateway uses the first provider with valid credentials.
+- **API Keys** — Create, list, and revoke personal API keys for programmatic access to `/v1/*` endpoints.
+- **Kiro Token Management** — Legacy per-user Kiro token management (device code flow).
+
+### Configuration (`/_ui/config`) — Admin Only
+
+Gateway runtime configuration management:
+
+- View all configuration settings with current values
+- Edit settings with immediate hot-reload (where supported)
+- Configuration schema with field types, descriptions, and validation rules
+- Configuration change history with timestamps and old/new values
+
+### Guardrails (`/_ui/guardrails`) — Admin Only
+
+Content safety configuration powered by AWS Bedrock:
+
+- **Profiles** — Create and manage AWS Bedrock guardrail connections (guardrail ID, version, region, AWS credentials). Enable/disable individually. Test profiles against sample content.
+- **Rules** — Define when guardrails apply using CEL expressions. Configure apply direction (input/output/both), sampling rate, timeout, and linked profiles. Validate CEL syntax before saving.
+
+### MCP Clients (`/_ui/mcp`) — Admin Only
+
+MCP (Model Context Protocol) tool server management:
+
+- **Add/Edit Clients** — Configure MCP server connections with HTTP, SSE, or STDIO transport. Set authentication headers and tool whitelists.
+- **Connection Status** — Monitor each server's connection state (Connected, Connecting, Disconnected, Error).
+- **Tool Discovery** — View discovered tools per server with auto-refresh intervals.
+- **Reconnect** — Force disconnect and reconnect to refresh tool lists or recover from errors.
+
+### Admin (`/_ui/admin`) — Admin Only
+
+User and access management:
+
+- **User List** — View all registered users with their roles, status, and last login.
+- **User Detail** (`/_ui/admin/users/:userId`) — View individual user details, change roles (Admin/User), manage user status.
+- **Domain Allowlist** — Restrict Google SSO sign-in to specific email domains.
+
+### Login (`/_ui/login`)
+
+Google SSO login page with PKCE flow. Unauthenticated users are redirected here automatically.
 
 ---
 
@@ -209,6 +269,14 @@ Each user manages their own Kiro (AWS CodeWhisperer) credentials. When a request
 - Kiro tokens are cached in memory (`kiro_token_cache`) with a 4-minute TTL
 - Tokens auto-refresh before expiry
 - Managed via the Kiro token routes in the dashboard
+
+### Multi-Provider Credentials
+
+In addition to Kiro, users can connect GitHub Copilot and Qwen Coder accounts on the Profile page:
+
+- **GitHub Copilot** — OAuth authorization code flow. Requires server-side configuration (`GITHUB_COPILOT_CLIENT_ID`, `GITHUB_COPILOT_CLIENT_SECRET`, `GITHUB_COPILOT_CALLBACK_URL`).
+- **Qwen Coder** — Device code flow. Requires `QWEN_OAUTH_CLIENT_ID` in server configuration.
+- **Provider Priority** — Users set a priority order for provider fallback. The gateway routes requests to the highest-priority provider with valid credentials.
 
 ### Domain Allowlist (Admin)
 
@@ -448,6 +516,9 @@ These require a valid session and CSRF token.
 | `POST` | `/_ui/api/auth/logout` | End current session |
 | `*` | `/_ui/api/kiro/*` | Kiro token management (per-user) |
 | `*` | `/_ui/api/keys/*` | API key management (per-user) |
+| `*` | `/_ui/api/copilot/*` | GitHub Copilot OAuth connect/disconnect (per-user) |
+| `*` | `/_ui/api/qwen/*` | Qwen Coder device flow connect/disconnect (per-user) |
+| `*` | `/_ui/api/providers/*` | Provider OAuth relay and priority management (per-user) |
 
 ### Admin-Only Endpoints (Session + CSRF + Admin Role)
 
@@ -471,6 +542,11 @@ The web UI is implemented across several Rust modules in `backend/src/web_ui/`:
 - **`session.rs`** — Session cookie management and CSRF validation
 - **`api_keys.rs`** — Per-user API key CRUD (create, list, revoke)
 - **`user_kiro.rs`** — Per-user Kiro token management
+- **`copilot_auth.rs`** — GitHub Copilot OAuth connect/callback/status/disconnect
+- **`qwen_auth.rs`** — Qwen Coder device flow connect/poll/status/disconnect
+- **`provider_oauth.rs`** — Multi-provider OAuth relay and public callback routes
+- **`provider_priority.rs`** — Per-user provider priority ordering
+- **`users.rs`** — User management (admin)
 - **`config_api.rs`** — Configuration validation, change classification, and field descriptions
 - **`config_db.rs`** — PostgreSQL persistence layer for configuration key-value storage
 

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -7,8 +7,9 @@ nav_order: 1
 <div class="hero" markdown="0">
   <h1>Kiro Gateway</h1>
   <p class="tagline">
-    A multi-user Rust proxy that lets you use OpenAI and Anthropic client libraries
-    with the Kiro API (AWS CodeWhisperer) backend. Deployed via Docker Compose with automated TLS.
+    A multi-user, multi-provider Rust proxy gateway. Use OpenAI and Anthropic client libraries
+    with Kiro, GitHub Copilot, and Qwen Coder backends. Per-user auth, content guardrails,
+    MCP tool gateway, and real-time streaming — deployed via Docker Compose with automated TLS.
   </p>
   <div class="badges">
     <span class="badge badge--infra">Rust</span>
@@ -16,15 +17,18 @@ nav_order: 1
     <span class="badge badge--api">OpenAI Compatible</span>
     <span class="badge badge--api">Anthropic Compatible</span>
     <span class="badge badge--core">Streaming</span>
-    <span class="badge badge--security">Multi-User</span>
+    <span class="badge badge--security">Multi-User RBAC</span>
     <span class="badge badge--core">MCP Gateway</span>
     <span class="badge badge--security">Content Guardrails</span>
+    <span class="badge badge--provider">Kiro</span>
+    <span class="badge badge--provider">Copilot</span>
+    <span class="badge badge--provider">Qwen Coder</span>
   </div>
 </div>
 
 ## How It Works
 
-Kiro Gateway sits between your existing AI client code and the Kiro API. Send requests in OpenAI or Anthropic format -- the gateway translates them on the fly, handles per-user authentication, and streams responses back in the format your client expects.
+Kiro Gateway sits between your existing AI client code and multiple provider backends. Send requests in OpenAI or Anthropic format -- the gateway translates them on the fly, handles per-user authentication with role-based access control, applies content guardrails, injects MCP tools, and streams responses back in the format your client expects.
 
 ```mermaid
 flowchart TD
@@ -37,16 +41,22 @@ flowchart TD
         NGINX["nginx (TLS)"]
         subgraph GW["Backend"]
             MW["Middleware\n(CORS, Auth)"]
-            GUARD["Guardrails"]
+            GUARD["Guardrails\n(CEL + Bedrock)"]
             MCP_INJ["MCP Tools"]
             CONV["Format Converters"]
             STREAM["Stream Parser"]
         end
     end
 
-    subgraph External["External Services"]
+    subgraph Providers["Provider Backends"]
         KIRO["Kiro API\n(CodeWhisperer)"]
-        SSO["AWS SSO OIDC"]
+        COPILOT["GitHub Copilot"]
+        QWEN["Qwen Coder"]
+    end
+
+    subgraph Auth["Authentication"]
+        SSO["Google SSO"]
+        DEVICE["Device Code\nOAuth"]
     end
 
     OAI --> NGINX
@@ -56,9 +66,14 @@ flowchart TD
     GUARD --> MCP_INJ
     MCP_INJ --> CONV
     CONV --> KIRO
+    CONV --> COPILOT
+    CONV --> QWEN
     KIRO --> STREAM
+    COPILOT --> STREAM
+    QWEN --> STREAM
     STREAM --> NGINX
     GW -.-> SSO
+    GW -.-> DEVICE
 ```
 
 ## Features
@@ -72,29 +87,37 @@ flowchart TD
     <h3><span class="fc-icon">&harr;</span> Anthropic Compatible</h3>
     <p>Full support for the Anthropic Messages API, including system prompts, tool use, and content blocks.</p>
   </div>
+  <div class="feature-card" data-cat="provider">
+    <h3><span class="fc-icon">&#9670;</span> Multi-Provider</h3>
+    <p>Connect to Kiro (AWS CodeWhisperer), GitHub Copilot, and Qwen Coder backends. Per-user credentials with automatic token refresh.</p>
+  </div>
   <div class="feature-card" data-cat="core">
     <h3><span class="fc-icon">&sim;</span> Real-time Streaming</h3>
-    <p>Parses Kiro's AWS Event Stream binary format and converts to standard SSE in real time.</p>
+    <p>Parses provider-specific binary formats and converts to standard SSE in real time. Supports AWS Event Stream and chunked transfer.</p>
   </div>
   <div class="feature-card" data-cat="security">
-    <h3><span class="fc-icon">&#9899;</span> Multi-User Auth</h3>
-    <p>Google SSO for web UI access, per-user API keys for programmatic access. Role-based access control (Admin/User).</p>
+    <h3><span class="fc-icon">&#9899;</span> Multi-User RBAC</h3>
+    <p>Google SSO for web UI, per-user API keys for programmatic access. Admin and User roles with domain allowlisting.</p>
   </div>
   <div class="feature-card" data-cat="core">
     <h3><span class="fc-icon">&#10023;</span> Extended Thinking</h3>
     <p>Extracts reasoning blocks from model responses and maps them to native thinking/reasoning content fields.</p>
   </div>
-  <div class="feature-card" data-cat="feature">
-    <h3><span class="fc-icon">&#9638;</span> Web Dashboard</h3>
-    <p>Built-in web UI for configuration, user management, API key management, and real-time log streaming.</p>
-  </div>
   <div class="feature-card" data-cat="core">
     <h3><span class="fc-icon">&#8644;</span> MCP Gateway</h3>
-    <p>Connect external MCP tool servers over HTTP, SSE, or STDIO. Tools are automatically discovered and injected into chat requests with per-request filtering.</p>
+    <p>Connect external MCP tool servers over HTTP, SSE, or STDIO. Tools are automatically discovered and injected into chat requests.</p>
   </div>
   <div class="feature-card" data-cat="security">
     <h3><span class="fc-icon">&#9681;</span> Content Guardrails</h3>
-    <p>AWS Bedrock-powered content validation with CEL rule engine. Validate input before sending and output before returning, with configurable sampling and fail-open design.</p>
+    <p>AWS Bedrock-powered content validation with CEL rule engine. Validate input and output with configurable sampling and fail-open design.</p>
+  </div>
+  <div class="feature-card" data-cat="feature">
+    <h3><span class="fc-icon">&#9638;</span> Web Dashboard</h3>
+    <p>Built-in CRT-styled web UI for configuration, user management, API keys, provider setup, and real-time log streaming.</p>
+  </div>
+  <div class="feature-card" data-cat="feature">
+    <h3><span class="fc-icon">&#9654;</span> Proxy-Only Mode</h3>
+    <p>Single-container deployment with no database or SSO required. Device code OAuth flow for quick setup behind any reverse proxy.</p>
   </div>
 </div>
 
@@ -115,6 +138,12 @@ docker compose up -d --build
 ```
 
 Then open `https://your-domain.com/_ui/` to complete setup via Google SSO.
+
+For proxy-only mode (no database, single container):
+
+```bash
+docker compose -f docker-compose.gateway.yml --env-file .env.proxy up -d
+```
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- Converts gh-pages documentation site from teal/glass-morphism aesthetic to match the frontend's CRT phosphor terminal theme (green #4ade80, JetBrains Mono, scanlines, glow effects, sharp borders)
- Updates all 15 documentation pages to reflect current architecture: multi-provider support (Kiro, Copilot, Qwen), guardrails engine, MCP gateway, proxy-only mode
- Fixes 2 leftover old-color files (`_includes/head_custom.html`, `_includes/mermaid_config.html`) and updates mermaid diagram theme to green/dark

## Test plan
- [ ] Verify gh-pages builds successfully with `cd gh-pages && bundle exec jekyll build`
- [ ] Visual check: landing page hero, feature cards, nav cards use CRT green aesthetic
- [ ] Confirm no leftover teal (#00d4aa) color references remain
- [ ] Verify all 36 mermaid diagrams render correctly
- [ ] Check responsive layout at 800px and 500px breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)