### PR TITLE
fix: use _config.yml baseurl instead of configure-pages override

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build with Jekyll
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -17,7 +17,7 @@
       "args": [
         "@playwright/mcp@latest",
         "--user-data-dir",
-        "/Users/hikennoace/ai-gateway/rkgw/.playwright-mcp/profile"
+        "/Users/hikennoace/ai-gateway/harbangan/.playwright-mcp/profile"
       ]
     }
   }


### PR DESCRIPTION
## Summary

- Remove `--baseurl` CLI override from Jekyll build step in `pages.yml` — after the repo rename, `actions/configure-pages` returned the stale `/rkgw` path, breaking all asset URLs on GitHub Pages
- Fix `.mcp.json` playwright path to use renamed repo directory

Jekyll will now use `baseurl: "/harbangan"` from `_config.yml` directly.

## Test plan

- [ ] Pages workflow completes successfully
- [ ] `https://if414013.github.io/harbangan/` loads with no console errors
- [ ] All nav links point to `/harbangan/...`, not `/rkgw/...`
- [ ] CSS/JS assets load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)