### PR TITLE
feat: replace Kiro logo with Harbangan gate logo

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -25,8 +25,8 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   return (
     <nav className={`sidebar${open ? ' open' : ''}`} aria-label="Main navigation" onClick={e => e.stopPropagation()}>
       <div className="sidebar-brand">
-        <h1 aria-label="Kiro"><span aria-hidden="true">{'  _  ___\n | |/ (_)_ _ ___\n | \' <| | \'_/ _ \\\n |_|\\_\\_|_| \\___/'}</span></h1>
-        <div className="version">gateway v1.0.8</div>
+        <h1 aria-label="Harbangan"><span aria-hidden="true">{'  ╔◈╗   ╔◈╗\n  ║ ║   ║ ║\n  ╠═╩═◈═╩═╣\n  ║ │   │ ║\n  ╚═╧═◈═╧═╝\n HARBANGAN'}</span></h1>
+        <div className="version">v1.0.8</div>
       </div>
       <div className="sidebar-nav">
         <NavLink to="/profile" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`} onClick={onClose}>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -46,10 +46,10 @@ export function Login() {
       <div className="auth-card">
         <div className="auth-logo">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--bg)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/>
+            <path d="M6 2v20"/><path d="M18 2v20"/><path d="M6 2h12"/><path d="M6 22h12"/><path d="M12 8l2.5 2.5-2.5 2.5-2.5-2.5z"/>
           </svg>
         </div>
-        <h2><span aria-hidden="true">{'> '}</span>KIRO GATEWAY<span className="cursor" aria-hidden="true" /></h2>
+        <h2><span aria-hidden="true">{'> '}</span>HARBANGAN<span className="cursor" aria-hidden="true" /></h2>
         <p>sign in to continue</p>
 
         {error && (


### PR DESCRIPTION
## Summary
- Replaced sidebar ASCII art with a Batak gorga-inspired gate logo using box-drawing characters and diamond motifs (◈)
- Updated login page SVG from layers icon to a gate icon with centered gorga diamond
- Changed all branding from "KIRO GATEWAY" to "HARBANGAN"

## Test plan
- [ ] Verify sidebar logo renders correctly in dark and light themes
- [ ] Verify login page gate icon and heading display properly
- [ ] Check responsive layout on mobile (sidebar collapsed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)