### PR TITLE
chore: remove outdated kiro-gateway reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Rust](https://img.shields.io/badge/rust-1.75+-orange.svg)](https://www.rust-lang.org/)
 
-_A Rust rewrite of [kiro-gateway](https://github.com/jwadow/kiro-gateway) — Use Claude models through any OpenAI or Anthropic compatible tool_
-
 </div>
 
 ---


### PR DESCRIPTION
## Summary
- Removed the "A Rust rewrite of kiro-gateway" tagline from README since the project has been fully rebranded to Harbangan

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)