### PR TITLE
feat(auth): allow SSO users to set password from profile

### DIFF
--- a/backend/src/web_ui/password_auth.rs
+++ b/backend/src/web_ui/password_auth.rs
@@ -554,16 +554,16 @@ pub async fn change_password_handler(
         .map_err(ApiError::Internal)?
         .ok_or(ApiError::SessionExpired)?;
 
-    let stored_hash = user
-        .5
-        .ok_or_else(|| ApiError::ValidationError("No password set for this account".to_string()))?;
+    let stored_hash: Option<String> = user.5;
 
-    // Verify current password
-    let valid =
-        verify_password(&payload.current_password, &stored_hash).map_err(ApiError::Internal)?;
-    if !valid {
-        return Err(ApiError::InvalidCredentials);
+    if let Some(ref hash) = stored_hash {
+        // Existing user with password — verify current password
+        let valid = verify_password(&payload.current_password, hash).map_err(ApiError::Internal)?;
+        if !valid {
+            return Err(ApiError::InvalidCredentials);
+        }
     }
+    // else: SSO user setting initial password — no verification needed
 
     // Hash new password
     let new_hash = hash_password(&payload.new_password).map_err(ApiError::Internal)?;
@@ -577,6 +577,7 @@ pub async fn change_password_handler(
     for mut entry in state.session_cache.iter_mut() {
         if entry.value().user_id == session.user_id {
             entry.value_mut().must_change_password = false;
+            entry.value_mut().auth_method = "password".to_string();
         }
     }
 

--- a/frontend/src/pages/PasswordChange.tsx
+++ b/frontend/src/pages/PasswordChange.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { changePassword } from '../lib/api'
+import { useSession } from '../components/SessionGate'
 
 export function PasswordChange() {
   const navigate = useNavigate()
+  const { user } = useSession()
+  const isInitialSetup = user.auth_method !== 'password'
   const [currentPassword, setCurrentPassword] = useState('')
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -26,7 +29,7 @@ export function PasswordChange() {
     setError(null)
     setSubmitting(true)
     try {
-      await changePassword(currentPassword, newPassword)
+      await changePassword(isInitialSetup ? '' : currentPassword, newPassword)
       navigate('/', { replace: true })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to change password')
@@ -43,8 +46,8 @@ export function PasswordChange() {
             <rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
           </svg>
         </div>
-        <h2><span aria-hidden="true">{'> '}</span>CHANGE PASSWORD<span className="cursor" aria-hidden="true" /></h2>
-        <p>you must update your password to continue</p>
+        <h2><span aria-hidden="true">{'> '}</span>{isInitialSetup ? 'SET PASSWORD' : 'CHANGE PASSWORD'}<span className="cursor" aria-hidden="true" /></h2>
+        <p>{isInitialSetup ? 'create a password for your account' : 'you must update your password to continue'}</p>
 
         {error && (
           <div className="login-error" role="alert" aria-live="assertive">
@@ -53,16 +56,18 @@ export function PasswordChange() {
         )}
 
         <form onSubmit={handleSubmit}>
-          <input
-            className="auth-input"
-            type="password"
-            placeholder="current password"
-            value={currentPassword}
-            onChange={e => setCurrentPassword(e.target.value)}
-            autoComplete="current-password"
-            required
-            autoFocus
-          />
+          {!isInitialSetup && (
+            <input
+              className="auth-input"
+              type="password"
+              placeholder="current password"
+              value={currentPassword}
+              onChange={e => setCurrentPassword(e.target.value)}
+              autoComplete="current-password"
+              required
+              autoFocus
+            />
+          )}
           <input
             className="auth-input"
             type="password"
@@ -84,7 +89,9 @@ export function PasswordChange() {
             minLength={8}
           />
           <button className="auth-submit" type="submit" disabled={submitting}>
-            {submitting ? '$ updating...' : '$ update password'}
+            {submitting
+              ? (isInitialSetup ? '$ setting...' : '$ updating...')
+              : (isInitialSetup ? '$ set password' : '$ update password')}
           </button>
         </form>
       </div>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,10 +1,17 @@
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ApiKeyManager } from '../components/ApiKeyManager'
 import { useSession } from '../components/SessionGate'
+import { getStatus } from '../lib/api'
 
 export function Profile() {
   const { user } = useSession()
   const navigate = useNavigate()
+  const [passwordAuthEnabled, setPasswordAuthEnabled] = useState(false)
+
+  useEffect(() => {
+    getStatus().then(s => setPasswordAuthEnabled(s.auth_password_enabled)).catch(() => {})
+  }, [])
 
   return (
     <>
@@ -51,28 +58,43 @@ export function Profile() {
         <ApiKeyManager />
       </div>
 
-      {user.auth_method === 'password' && (
+      {passwordAuthEnabled && (
         <>
           <h2 className="section-header">SECURITY</h2>
           <div className="card">
             <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                <span style={{ fontSize: '0.72rem', color: 'var(--text-secondary)' }}>
-                  2FA: {user.totp_enabled ? (
-                    <span style={{ color: 'var(--green)' }}>ENABLED</span>
-                  ) : (
-                    <span style={{ color: 'var(--red)' }}>NOT SET UP</span>
-                  )}
-                </span>
-              </div>
-              <div style={{ display: 'flex', gap: 8 }}>
-                <button className="btn-save" type="button" onClick={() => navigate('/change-password')}>
-                  $ change password
-                </button>
-                <button className="btn-save" type="button" onClick={() => navigate('/setup-2fa')}>
-                  $ reset 2fa
-                </button>
-              </div>
+              {user.auth_method === 'password' ? (
+                <>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <span style={{ fontSize: '0.72rem', color: 'var(--text-secondary)' }}>
+                      2FA: {user.totp_enabled ? (
+                        <span style={{ color: 'var(--green)' }}>ENABLED</span>
+                      ) : (
+                        <span style={{ color: 'var(--red)' }}>NOT SET UP</span>
+                      )}
+                    </span>
+                  </div>
+                  <div style={{ display: 'flex', gap: 8 }}>
+                    <button className="btn-save" type="button" onClick={() => navigate('/change-password')}>
+                      $ change password
+                    </button>
+                    <button className="btn-save" type="button" onClick={() => navigate('/setup-2fa')}>
+                      $ reset 2fa
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <span style={{ fontSize: '0.72rem', color: 'var(--text-secondary)' }}>
+                    set a password to enable 2FA and password login
+                  </span>
+                  <div>
+                    <button className="btn-save" type="button" onClick={() => navigate('/change-password')}>
+                      $ set password
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </>


### PR DESCRIPTION
## Summary

- Profile SECURITY section now shows for all users when password auth is enabled system-wide (checks `auth_password_enabled` from status endpoint instead of `user.auth_method`)
- SSO users see "$ set password" — backend skips current password verification when `password_hash` is NULL
- After setting a password, session `auth_method` updates to "password" so full security controls (change password, reset 2FA, 2FA status) appear immediately

## Test plan

- [x] Admin enables both Google SSO + password auth in Config
- [x] SSO user (no password) sees SECURITY section with "$ set password" button
- [x] SSO user sets password successfully without providing current password
- [x] After setting password, full security controls appear (change password, reset 2FA, 2FA status)
- [x] Password-auth user sees full SECURITY section as before
- [x] When admin disables password auth, SECURITY section disappears for all users
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test --lib` — zero failures
- [x] `npm run build && npm run lint` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)