### PR TITLE
feat(model): admin-only model loading, no providers enabled by default

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -237,41 +237,11 @@ async fn main() -> Result<()> {
     // Add hidden models to cache
     add_hidden_models(&model_cache);
 
-    // ── Model registry population ────────────────────────────────
-    // Populate static models into the DB for each direct provider,
-    // then load enabled models into the in-memory registry cache.
+    // ── Model registry cache ───────────────────────────────────
+    // Load admin-enabled registry models into in-memory cache.
+    // Models are populated on-demand via the admin UI, not on startup.
     if !is_proxy_only {
-        if let Some(ref db) = config_db {
-            let providers = ["anthropic", "openai_codex", "qwen"];
-            for provider_id in &providers {
-                match web_ui::model_registry::populate_provider(
-                    provider_id,
-                    db,
-                    &http_client,
-                    None, // No auth_manager needed for static-only providers
-                )
-                .await
-                {
-                    Ok(count) => {
-                        if count > 0 {
-                            tracing::info!(
-                                provider = provider_id,
-                                count,
-                                "Populated model registry"
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            provider = provider_id,
-                            error = %e,
-                            "Failed to populate model registry"
-                        );
-                    }
-                }
-            }
-
-            // Load enabled registry models into in-memory cache
+        if let Some(ref _db) = config_db {
             match model_cache.load_from_registry().await {
                 Ok(count) => {
                     tracing::info!(count, "Loaded registry models into cache");

--- a/backend/src/web_ui/model_registry.rs
+++ b/backend/src/web_ui/model_registry.rs
@@ -35,7 +35,7 @@ fn static_to_registry(provider_id: &str, models: Vec<StaticModel>) -> Vec<Regist
             context_length: m.context_length,
             max_output_tokens: m.max_output_tokens,
             capabilities: m.capabilities,
-            enabled: true,
+            enabled: false,
             source: "static".to_string(),
             upstream_meta: None,
             created_at: now,
@@ -320,7 +320,7 @@ pub async fn fetch_kiro_models(
                 context_length: 0,
                 max_output_tokens: 0,
                 capabilities: json!({}),
-                enabled: true,
+                enabled: false,
                 source: "api".to_string(),
                 upstream_meta: Some(json!({ "internal_id": internal_id })),
                 created_at: now,
@@ -464,7 +464,7 @@ pub async fn fetch_anthropic_models(
                 context_length: 0,
                 max_output_tokens: 0,
                 capabilities: json!({}),
-                enabled: true,
+                enabled: false,
                 source: "api".to_string(),
                 upstream_meta: Some(m.clone()),
                 created_at: now,
@@ -499,7 +499,7 @@ pub(crate) fn parse_openai_models_response(
                 context_length: 0,
                 max_output_tokens: 0,
                 capabilities: json!({}),
-                enabled: true,
+                enabled: false,
                 source: "api".to_string(),
                 upstream_meta: Some(m.clone()),
                 created_at: now,
@@ -641,7 +641,7 @@ mod tests {
         for m in &models {
             assert_eq!(m.provider_id, "anthropic");
             assert_eq!(m.source, "static");
-            assert!(m.enabled);
+            assert!(!m.enabled);
             assert!(m.prefixed_id.starts_with("anthropic/"));
         }
     }


### PR DESCRIPTION
## Summary
- Remove startup auto-population that pre-loaded ~26 models for anthropic, openai_codex, and qwen on every boot
- Default all newly populated models to `enabled: false` — admins must explicitly enable models via the UI
- Existing admin-enabled models in the DB are unaffected (ON CONFLICT upsert preserves `enabled` state)

## Test plan
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test --lib` — 743 tests pass
- [x] Fresh DB: model registry starts empty, no models available until admin clicks Populate
- [x] After Populate: models appear with `enabled: false`, admin toggles individual models on
- [ ] Existing DB: previously enabled models remain enabled after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)