### PR TITLE
feat(converter): handle server-side tool types (web_search, web_fetch)

### DIFF
--- a/backend/src/converters/anthropic_to_kiro.rs
+++ b/backend/src/converters/anthropic_to_kiro.rs
@@ -252,17 +252,91 @@ pub fn convert_anthropic_messages(messages: &[AnthropicMessage]) -> Vec<UnifiedM
 }
 
 /// Converts Anthropic tools to unified format.
+///
+/// Handles both regular custom tools and server-side tools (web_search, web_fetch, etc.).
+/// Server-side tools are converted to regular tool definitions with a synthetic input_schema
+/// so they can be passed to the Kiro API as standard tool definitions.
 pub fn convert_anthropic_tools(tools: &Option<Vec<AnthropicTool>>) -> Option<Vec<UnifiedTool>> {
     tools.as_ref().map(|tools| {
         tools
             .iter()
-            .map(|tool| UnifiedTool {
-                name: tool.name.clone(),
-                description: tool.description.clone(),
-                input_schema: Some(tool.input_schema.clone()),
+            .map(|tool| match tool {
+                AnthropicTool::Custom(custom) => UnifiedTool {
+                    name: custom.name.clone(),
+                    description: custom.description.clone(),
+                    input_schema: Some(custom.input_schema.clone()),
+                },
+                AnthropicTool::ServerSide(server_tool) => {
+                    debug!(
+                        "Converting Anthropic server-side tool '{}' (type={}) to regular tool definition",
+                        server_tool.name, server_tool.tool_type
+                    );
+                    let (description, schema) =
+                        server_side_tool_to_schema(&server_tool.tool_type, &server_tool.name);
+                    UnifiedTool {
+                        name: server_tool.name.clone(),
+                        description: Some(description),
+                        input_schema: Some(schema),
+                    }
+                }
             })
             .collect()
     })
+}
+
+/// Generates a description and synthetic input schema for a server-side tool.
+fn server_side_tool_to_schema(tool_type: &str, name: &str) -> (String, serde_json::Value) {
+    // Match on the tool name prefix since versions vary
+    if name == "web_search" || tool_type.starts_with("web_search_") {
+        (
+            "Search the web for real-time information. Returns up to 10 search results."
+                .to_string(),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query to look up on the web"
+                    }
+                },
+                "required": ["query"]
+            }),
+        )
+    } else if name == "web_fetch" || tool_type.starts_with("web_fetch_") {
+        (
+            "Fetch and retrieve content from a specific URL.".to_string(),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "The URL to fetch content from"
+                    },
+                    "mode": {
+                        "type": "string",
+                        "description": "Fetch mode: selective (default), truncated, or full",
+                        "enum": ["selective", "truncated", "full"]
+                    }
+                },
+                "required": ["url"]
+            }),
+        )
+    } else {
+        // Generic fallback for other server-side tools (bash, text_editor, etc.)
+        (
+            format!("Server-side tool: {} (type: {})", name, tool_type),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "input": {
+                        "type": "string",
+                        "description": "Input for the tool"
+                    }
+                },
+                "required": ["input"]
+            }),
+        )
+    }
 }
 
 // ==================================================================================================
@@ -320,6 +394,7 @@ pub fn build_kiro_payload(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::anthropic::{AnthropicCustomTool, AnthropicServerSideTool};
     use serde_json::json;
 
     // ==================================================================================================
@@ -751,11 +826,11 @@ mod tests {
 
     #[test]
     fn test_convert_anthropic_tools() {
-        let tools = vec![AnthropicTool {
+        let tools = vec![AnthropicTool::Custom(AnthropicCustomTool {
             name: "get_weather".to_string(),
             description: Some("Get weather".to_string()),
             input_schema: json!({"type": "object"}),
-        }];
+        })];
 
         let unified = convert_anthropic_tools(&Some(tools));
         assert!(unified.is_some());
@@ -780,16 +855,16 @@ mod tests {
     #[test]
     fn test_convert_anthropic_tools_multiple() {
         let tools = vec![
-            AnthropicTool {
+            AnthropicTool::Custom(AnthropicCustomTool {
                 name: "tool_a".to_string(),
                 description: Some("Tool A".to_string()),
                 input_schema: json!({"type": "object", "properties": {"x": {"type": "string"}}}),
-            },
-            AnthropicTool {
+            }),
+            AnthropicTool::Custom(AnthropicCustomTool {
                 name: "tool_b".to_string(),
                 description: None,
                 input_schema: json!({"type": "object"}),
-            },
+            }),
         ];
 
         let unified = convert_anthropic_tools(&Some(tools));
@@ -800,5 +875,44 @@ mod tests {
         assert!(tools[0].description.is_some());
         assert_eq!(tools[1].name, "tool_b");
         assert!(tools[1].description.is_none());
+    }
+
+    #[test]
+    fn test_convert_anthropic_server_side_web_search_tool() {
+        let tools = vec![AnthropicTool::ServerSide(AnthropicServerSideTool {
+            tool_type: "web_search_20250305".to_string(),
+            name: "web_search".to_string(),
+            max_uses: Some(5),
+            extra: std::collections::HashMap::new(),
+        })];
+
+        let unified = convert_anthropic_tools(&Some(tools));
+        assert!(unified.is_some());
+        let tools = unified.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "web_search");
+        assert!(tools[0].description.is_some());
+        assert!(tools[0].input_schema.is_some());
+        // Should have a query parameter in the schema
+        let schema = tools[0].input_schema.as_ref().unwrap();
+        assert!(schema["properties"]["query"].is_object());
+    }
+
+    #[test]
+    fn test_convert_anthropic_server_side_web_fetch_tool() {
+        let tools = vec![AnthropicTool::ServerSide(AnthropicServerSideTool {
+            tool_type: "web_fetch_20250910".to_string(),
+            name: "web_fetch".to_string(),
+            max_uses: None,
+            extra: std::collections::HashMap::new(),
+        })];
+
+        let unified = convert_anthropic_tools(&Some(tools));
+        assert!(unified.is_some());
+        let tools = unified.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "web_fetch");
+        let schema = tools[0].input_schema.as_ref().unwrap();
+        assert!(schema["properties"]["url"].is_object());
     }
 }

--- a/backend/src/converters/openai_to_kiro.rs
+++ b/backend/src/converters/openai_to_kiro.rs
@@ -253,15 +253,36 @@ pub fn convert_openai_messages_to_unified(
 }
 
 /// Converts OpenAI tools to unified format.
+///
+/// Handles both regular function tools and server-side tools (web_search_preview, etc.).
+/// Server-side tools are converted to regular tool definitions with a synthetic schema.
 pub fn convert_openai_tools_to_unified(tools: &Option<Vec<Tool>>) -> Option<Vec<UnifiedTool>> {
     tools.as_ref().map(|tools| {
         tools
             .iter()
-            .filter(|tool| tool.tool_type == "function")
-            .map(|tool| UnifiedTool {
-                name: tool.function.name.clone(),
-                description: tool.function.description.clone(),
-                input_schema: tool.function.parameters.clone(),
+            .filter_map(|tool| match tool {
+                Tool::Function(ft) if ft.tool_type == "function" => Some(UnifiedTool {
+                    name: ft.function.name.clone(),
+                    description: ft.function.description.clone(),
+                    input_schema: ft.function.parameters.clone(),
+                }),
+                Tool::Function(_) => None, // non-function FunctionTool (shouldn't happen)
+                Tool::ServerSide(st) => {
+                    debug!(
+                        "Converting OpenAI server-side tool type='{}' to regular tool definition",
+                        st.tool_type
+                    );
+                    let name = st.tool_type.clone();
+                    let description = format!("Server-side tool: {}", st.tool_type);
+                    Some(UnifiedTool {
+                        name,
+                        description: Some(description),
+                        input_schema: Some(serde_json::json!({
+                            "type": "object",
+                            "properties": {},
+                        })),
+                    })
+                }
             })
             .collect()
     })
@@ -566,7 +587,7 @@ pub fn build_kiro_payload_core(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::openai::{FunctionCall, ToolCall, ToolFunction};
+    use crate::models::openai::{FunctionCall, FunctionTool, ToolCall, ToolFunction};
     use serde_json::json;
 
     fn create_test_config() -> Config {
@@ -603,14 +624,14 @@ mod tests {
 
     #[test]
     fn test_convert_openai_tools() {
-        let tools = vec![Tool {
+        let tools = vec![Tool::Function(FunctionTool {
             tool_type: "function".to_string(),
             function: ToolFunction {
                 name: "get_weather".to_string(),
                 description: Some("Get weather".to_string()),
                 parameters: Some(json!({"type": "object"})),
             },
-        }];
+        })];
 
         let unified = convert_openai_tools_to_unified(&Some(tools));
         assert!(unified.is_some());
@@ -881,7 +902,7 @@ mod tests {
             stop: None,
             presence_penalty: None,
             frequency_penalty: None,
-            tools: Some(vec![Tool {
+            tools: Some(vec![Tool::Function(FunctionTool {
                 tool_type: "function".to_string(),
                 function: ToolFunction {
                     name: "get_weather".to_string(),
@@ -893,7 +914,7 @@ mod tests {
                         }
                     })),
                 },
-            }]),
+            })]),
             tool_choice: None,
             stream_options: None,
             logit_bias: None,
@@ -1314,7 +1335,7 @@ mod tests {
             stop: None,
             presence_penalty: None,
             frequency_penalty: None,
-            tools: Some(vec![Tool {
+            tools: Some(vec![Tool::Function(FunctionTool {
                 // Tools ARE defined
                 tool_type: "function".to_string(),
                 function: ToolFunction {
@@ -1322,7 +1343,7 @@ mod tests {
                     description: Some("Read a file".to_string()),
                     parameters: Some(json!({"type": "object"})),
                 },
-            }]),
+            })]),
             tool_choice: None,
             stream_options: None,
             logit_bias: None,

--- a/backend/src/models/anthropic.rs
+++ b/backend/src/models/anthropic.rs
@@ -56,12 +56,39 @@ pub struct AnthropicMessage {
 // Tool Models
 // ==================================================================================================
 
+/// Anthropic tool definition — either a regular custom tool or a server-side tool.
+///
+/// Regular tools have `name`, `description`, `input_schema`.
+/// Server-side tools (web_search, web_fetch, bash, text_editor, etc.) have a `type`
+/// field like `web_search_20250305` and no `input_schema`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AnthropicTool {
+#[serde(untagged)]
+pub enum AnthropicTool {
+    /// Regular custom tool with input_schema
+    Custom(AnthropicCustomTool),
+    /// Server-side tool (web_search, web_fetch, bash, text_editor, etc.)
+    ServerSide(AnthropicServerSideTool),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicCustomTool {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub input_schema: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicServerSideTool {
+    /// Versioned type identifier (e.g., "web_search_20250305", "web_fetch_20250910")
+    #[serde(rename = "type")]
+    pub tool_type: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_uses: Option<i32>,
+    /// All other fields (allowed_domains, blocked_domains, user_location, etc.)
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/models/openai.rs
+++ b/backend/src/models/openai.rs
@@ -84,11 +84,33 @@ pub struct ToolFunction {
     pub parameters: Option<serde_json::Value>,
 }
 
+/// OpenAI tool definition — either a function tool or a server-side tool.
+///
+/// Function tools have `type: "function"` and a `function` field.
+/// Server-side tools (e.g., `web_search_preview`) have a different type and no `function` field.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Tool {
+#[serde(untagged)]
+pub enum Tool {
+    /// Regular function tool
+    Function(FunctionTool),
+    /// Server-side/built-in tool (web_search_preview, etc.)
+    ServerSide(ServerSideTool),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionTool {
     #[serde(rename = "type")]
     pub tool_type: String,
     pub function: ToolFunction,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerSideTool {
+    #[serde(rename = "type")]
+    pub tool_type: String,
+    /// All other fields vary by tool type
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/tokenizer.rs
+++ b/backend/src/tokenizer.rs
@@ -174,16 +174,23 @@ pub fn count_tools_tokens(tools: Option<&Vec<Tool>>, apply_claude_correction: bo
 
     for tool in tools_list {
         total_tokens += TOKENS_PER_TOOL;
-        total_tokens += count_tokens(&tool.tool_type, false);
-        total_tokens += count_tokens(&tool.function.name, false);
+        match tool {
+            Tool::Function(ft) => {
+                total_tokens += count_tokens(&ft.tool_type, false);
+                total_tokens += count_tokens(&ft.function.name, false);
 
-        if let Some(ref desc) = tool.function.description {
-            total_tokens += count_tokens(desc, false);
-        }
+                if let Some(ref desc) = ft.function.description {
+                    total_tokens += count_tokens(desc, false);
+                }
 
-        if let Some(ref params) = tool.function.parameters {
-            let params_str = serde_json::to_string(params).unwrap_or_default();
-            total_tokens += count_tokens(&params_str, false);
+                if let Some(ref params) = ft.function.parameters {
+                    let params_str = serde_json::to_string(params).unwrap_or_default();
+                    total_tokens += count_tokens(&params_str, false);
+                }
+            }
+            Tool::ServerSide(st) => {
+                total_tokens += count_tokens(&st.tool_type, false);
+            }
         }
     }
 
@@ -319,12 +326,21 @@ pub fn count_anthropic_message_tokens(
         for tool in tools_list {
             total_tokens += 4; // Service tokens
 
-            total_tokens += count_tokens(&tool.name, false);
-            if let Some(ref desc) = tool.description {
-                total_tokens += count_tokens(desc, false);
+            match tool {
+                AnthropicTool::Custom(custom) => {
+                    total_tokens += count_tokens(&custom.name, false);
+                    if let Some(ref desc) = custom.description {
+                        total_tokens += count_tokens(desc, false);
+                    }
+                    let schema_str =
+                        serde_json::to_string(&custom.input_schema).unwrap_or_default();
+                    total_tokens += count_tokens(&schema_str, false);
+                }
+                AnthropicTool::ServerSide(server) => {
+                    total_tokens += count_tokens(&server.name, false);
+                    total_tokens += count_tokens(&server.tool_type, false);
+                }
             }
-            let schema_str = serde_json::to_string(&tool.input_schema).unwrap_or_default();
-            total_tokens += count_tokens(&schema_str, false);
         }
     }
 
@@ -339,7 +355,7 @@ pub fn count_anthropic_message_tokens(
 mod tests {
     use super::*;
     use crate::models::anthropic::AnthropicMessage;
-    use crate::models::openai::{FunctionCall, ToolCall, ToolFunction};
+    use crate::models::openai::{FunctionCall, FunctionTool, ToolCall, ToolFunction};
     use serde_json::json;
 
     #[test]
@@ -483,7 +499,7 @@ mod tests {
 
     #[test]
     fn test_count_tools_tokens_simple() {
-        let tools = vec![Tool {
+        let tools = vec![Tool::Function(FunctionTool {
             tool_type: "function".to_string(),
             function: ToolFunction {
                 name: "get_weather".to_string(),
@@ -499,7 +515,7 @@ mod tests {
                     "required": ["location"]
                 })),
             },
-        }];
+        })];
         let tokens = count_tools_tokens(Some(&tools), false);
         // Should include: TOKENS_PER_TOOL (4) + type + name + description + parameters
         assert!(tokens > 10);
@@ -507,7 +523,7 @@ mod tests {
 
     #[test]
     fn test_count_tools_tokens_with_correction() {
-        let tools = vec![Tool {
+        let tools = vec![Tool::Function(FunctionTool {
             tool_type: "function".to_string(),
             function: ToolFunction {
                 name: "search_database".to_string(),
@@ -520,7 +536,7 @@ mod tests {
                     }
                 })),
             },
-        }];
+        })];
         let without_correction = count_tools_tokens(Some(&tools), false);
         let with_correction = count_tools_tokens(Some(&tools), true);
         assert!(with_correction > without_correction);
@@ -529,22 +545,22 @@ mod tests {
     #[test]
     fn test_count_tools_tokens_multiple() {
         let tools = vec![
-            Tool {
+            Tool::Function(FunctionTool {
                 tool_type: "function".to_string(),
                 function: ToolFunction {
                     name: "tool_one".to_string(),
                     description: Some("First tool".to_string()),
                     parameters: None,
                 },
-            },
-            Tool {
+            }),
+            Tool::Function(FunctionTool {
                 tool_type: "function".to_string(),
                 function: ToolFunction {
                     name: "tool_two".to_string(),
                     description: Some("Second tool".to_string()),
                     parameters: None,
                 },
-            },
+            }),
         ];
         let tokens = count_tools_tokens(Some(&tools), false);
         // Should be roughly double a single tool


### PR DESCRIPTION
## Summary
- Fix deserialization crash when clients send Anthropic server-side tools (`web_search_20250305`, `web_fetch_20250910`) or OpenAI server-side tools (`web_search_preview`)
- Convert server-side tools to regular `UnifiedTool` with synthetic input schemas so they can be passed to the Kiro API as standard `toolSpecification` definitions
- Update tokenizer to handle both custom and server-side tool enum variants

## Changes
- `AnthropicTool` → enum with `Custom` and `ServerSide` variants
- `Tool` (OpenAI) → enum with `Function` and `ServerSide` variants
- Added `server_side_tool_to_schema()` for web_search/web_fetch synthetic schemas
- Updated all test files to use new enum constructors
- 712 tests pass, 0 clippy warnings

## Test plan
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test --lib` — 712 passed, 0 failed
- [x] New tests for web_search and web_fetch server-side tool conversion
- [ ] Manual test: send Anthropic request with `web_search_20250305` tool definition
- [ ] Manual test: send OpenAI request with `web_search_preview` tool type

🤖 Generated with [Claude Code](https://claude.com/claude-code)