### PR TITLE
fix(ci): fix worktree hook errors and project-automation workflow

### DIFF
--- a/.claude/hooks/block-sensitive-commits.sh
+++ b/.claude/hooks/block-sensitive-commits.sh
@@ -61,7 +61,7 @@ ENDJSON
 done
 
 # Block 'git add -A' and 'git add .' as they can accidentally include sensitive files
-if echo "$COMMAND" | grep -qE 'git\s+add\s+(-A|--all|\.($|\s|&&|;|\|))'; then
+if echo "$COMMAND" | grep -qE 'git\s+add\s+(-A|--all|\.\s*($|&&|;|\|))'; then
   cat <<ENDJSON
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Blocked: 'git add -A' / 'git add .' can accidentally stage sensitive files (.env, certs, auth state). Stage specific files by name instead."}}
 ENDJSON

--- a/.claude/hooks/worktree-guard-stop.sh
+++ b/.claude/hooks/worktree-guard-stop.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Stop hook: blocks downstream Stop hooks when running inside a worktree.
+# Worktree CWDs contain /.claude/worktrees/ which breaks plugins that
+# derive transcript paths from CWD.
+
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+if echo "$CWD" | grep -q '/\.claude/worktrees/'; then
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,6 +64,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/worktree-guard-stop.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -9,8 +9,11 @@ on:
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
     steps:
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/users/if414013/projects/1
           github-token: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary
- Add Stop hook guard that blocks downstream hooks in worktree contexts where transcript path resolution fails
- Pin `actions/add-to-project` to v1.0.2 and add job-level permissions
- Fix `block-sensitive-commits.sh` regex false positive on `git add .claude/`

## Test plan
- [x] Worktree guard returns exit 2 for worktree CWDs, exit 0 for normal CWDs
- [x] `git add .` still blocked, `git add .claude/...` now allowed
- [x] CI workflow validates with `gh workflow view`

🤖 Generated with [Claude Code](https://claude.com/claude-code)