### PR TITLE
chore(docker): remove datadog agent from local dev compose

### DIFF
--- a/.claude/plans/gentle-moseying-peach.md
+++ b/.claude/plans/gentle-moseying-peach.md
@@ -1,0 +1,31 @@
+# Remove Manual TLS/nginx Artifacts
+
+Docker Compose is dev-only. TLS will be handled by k8s Ingress later.
+
+## Files to Delete
+- `frontend/nginx.conf` — unused production nginx config
+- `certs/cert.pem`, `certs/key.pem` — unused self-signed certs
+
+## Files to Edit
+
+### Core Config
+- `.env.example` — remove `DOMAIN`, `EMAIL`, `USE_LOCAL_CA`, `STAGING` vars; change `GOOGLE_CALLBACK_URL` to `http://localhost:9999/_ui/api/auth/google/callback`
+- `.gitignore` — remove `certs/` entry if present
+- `CLAUDE.md` — update architecture diagram: remove nginx-certbot layer, show `frontend:5173` and `backend:9999` directly. Remove TLS env vars from table. Update "Docker Services" section.
+- `.claude/CLAUDE.md` — remove nginx reference if present
+- `.claude/agents/devops-engineer.md` — remove nginx/TLS/certbot from agent scope
+- `.claude/rules/web-ui.md` — remove "served by nginx" references (it's Vite in dev)
+
+### Documentation (gh-pages/)
+- `gh-pages/docs/deployment.md` — remove TLS/cert setup instructions
+- `gh-pages/docs/architecture/index.md` — update to remove nginx layer
+- `gh-pages/docs/architecture/request-flow.md` — remove nginx from flow
+- `gh-pages/docs/troubleshooting.md` — remove cert/nginx troubleshooting
+- `gh-pages/docs/configuration.md` — remove TLS config section
+- `gh-pages/docs/quickstart.md` — remove TLS setup steps
+- `gh-pages/docs/getting-started.md` — remove TLS setup steps
+
+## Verification
+```bash
+grep -ri "nginx\|certbot\|letsencrypt\|ssl_cert\|USE_LOCAL_CA\|jonasal" --include='*.md' --include='*.yml' --include='*.conf' --include='*.toml' --include='*.example' . | grep -v node_modules | grep -v target | grep -v '.git/'
+```

--- a/.claude/plans/shimmying-fluttering-bentley.md
+++ b/.claude/plans/shimmying-fluttering-bentley.md
@@ -1,0 +1,26 @@
+# Remove Datadog Agent from Local Dev Docker Compose
+
+## Files to Modify
+
+- **`docker-compose.yml`**
+  - Remove `datadog-agent` service definition (lines 78-96)
+  - Remove `datadog-run` volume (lines 98-100)
+  - Remove `depends_on: datadog-agent` from backend service (lines 48-49)
+  - Remove `DD_AGENT_HOST: datadog-agent` env var from backend (line 34)
+  - Remove `com.datadoghq.ad.logs` and `com.datadoghq.tags.*` labels from backend (lines 41-44)
+  - Remove `VITE_DD_*` env vars from frontend (lines 66-70)
+
+- **`docker-compose.gateway.yml`**
+  - Remove `datadog-agent` service (lines 58-76) — same reasoning applies
+  - Remove `com.datadoghq.tags.*` labels from gateway service (lines 40-43)
+
+- **`.env.example`**
+  - Move DD_* vars to a "Production / Kubernetes" section with a note that these are used in K8s deployment, not local dev
+
+No backend/frontend code changes needed — both already no-op when DD env vars are absent.
+
+## Verification
+
+```bash
+docker compose config --quiet && docker compose -f docker-compose.gateway.yml config --quiet
+```

--- a/.claude/plans/vivid-foraging-truffle.md
+++ b/.claude/plans/vivid-foraging-truffle.md
@@ -1,0 +1,45 @@
+# Fix worktree hook errors + add-to-project CI failure
+
+## 1. Worktree guard Stop hook
+
+The claude-mem plugin fires a Stop hook that fails in worktrees because the transcript path is derived from the worktree CWD. Add a worktree-aware guard.
+
+- **`.claude/settings.json`** (line 68, before closing `}` of hooks)
+  - Add a `Stop` hook array with a command hook pointing to a new guard script
+  - The Stop hook runs before the claude-mem plugin's internal hook
+
+- **`.claude/hooks/worktree-guard-stop.sh`** (new file)
+  - Read `cwd` from stdin JSON
+  - If CWD contains `/.claude/worktrees/`, exit with code 2 (block) to prevent downstream Stop hooks from running
+  - Otherwise exit 0 (allow)
+
+## 2. Fix add-to-project CI workflow
+
+`GITHUB_TOKEN` can't access user-level projects. Need a fine-grained PAT.
+
+- **`.github/workflows/project-automation.yml`** (lines 13-16)
+  - Update action from `actions/add-to-project@v1` to `actions/add-to-project@v1.0.2`
+  - Add `permissions: projects: write` at job level
+  - Keep using `PROJECT_TOKEN` secret (user must create fine-grained PAT with `project` read/write scope and store as repo secret)
+
+- **Manual step (not automatable):**
+  - User creates fine-grained PAT at github.com/settings/tokens with:
+    - Repository access: `if414013/harbangan`
+    - Permissions: Projects → Read and write
+  - Store as `PROJECT_TOKEN` repo secret
+
+## 3. Fix block-sensitive-commits.sh false positive
+
+- **`.claude/hooks/block-sensitive-commits.sh`**
+  - Fix the regex that blocks `git add .` to not match `git add .claude/...`
+  - Change pattern from `git add \.` to `git add \.$` (only match literal `git add .` at end)
+
+## Verification
+```bash
+# Hook test: simulate worktree CWD
+echo '{"cwd":"/path/.claude/worktrees/test"}' | .claude/hooks/worktree-guard-stop.sh; echo $?
+# Should output exit code 2
+
+# CI: validate workflow syntax
+gh workflow view project-automation.yml 2>&1 | head -5
+```

--- a/.env.example
+++ b/.env.example
@@ -12,27 +12,25 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CALLBACK_URL=http://localhost:9999/_ui/api/auth/google/callback
 
-# Datadog APM (optional — enables observability when set)
-# Start the Datadog Agent sidecar: docker compose --profile datadog up -d
+# ── Production / Kubernetes (not used in local dev) ──────────────
+# The Datadog agent runs at the Kubernetes cluster level, not as a
+# local Docker sidecar. Set these vars in your K8s deployment manifests
+# or Helm values — they are ignored by docker-compose.yml.
 #
-# Set DD_AGENT_HOST=datadog-agent when using the datadog profile:
-#   docker compose --profile datadog up -d
+# DD_API_KEY=
+# DD_SITE=datadoghq.com
+# DD_ENV=production
 # DD_AGENT_HOST=datadog-agent
-DD_API_KEY=
-DD_SITE=datadoghq.com
-
-# DD_AGENT_PORT=8126             # Datadog Agent trace port (default: 8126)
-# DD_SERVICE=harbangan-backend    # APM service name (set in backend code)
-DD_ENV=production
-# DD_VERSION=1.0.8               # Service version tag (aligns with CARGO_PKG_VERSION)
-
-# Datadog RUM — frontend browser monitoring (build-time, baked into JS bundle)
-# These must be set before running: docker compose build frontend
-VITE_DD_CLIENT_TOKEN=          # Required for RUM (get from Datadog → UX Monitoring → Setup)
-VITE_DD_APPLICATION_ID=        # Required for RUM (created with the RUM application)
-VITE_DD_ENV=production         # Optional (default: production)
-VITE_DD_SERVICE=harbangan-frontend  # Optional (default: harbangan-frontend)
-VITE_DD_SITE=datadoghq.com     # Optional (default: datadoghq.com; use datadoghq.eu for EU)
+# DD_AGENT_PORT=8126
+# DD_SERVICE=harbangan-backend
+# DD_VERSION=1.0.8
+#
+# Datadog RUM (frontend browser monitoring, build-time)
+# VITE_DD_CLIENT_TOKEN=
+# VITE_DD_APPLICATION_ID=
+# VITE_DD_ENV=production
+# VITE_DD_SERVICE=harbangan-frontend
+# VITE_DD_SITE=datadoghq.com
 
 # Initial admin account (optional — for headless/automated setup)
 # When set, the backend creates this admin user on first startup instead of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## GitHub
+
+- **Owner**: `if414013` — use this account for `gh` CLI operations
+- **Repo**: `if414013/harbangan`
+
 ## Project Structure
 
 ```

--- a/docker-compose.gateway.yml
+++ b/docker-compose.gateway.yml
@@ -37,10 +37,6 @@ services:
       GITHUB_COPILOT_CLIENT_ID: "${GITHUB_COPILOT_CLIENT_ID:-}"
       GITHUB_COPILOT_CLIENT_SECRET: "${GITHUB_COPILOT_CLIENT_SECRET:-}"
       GITHUB_COPILOT_CALLBACK_URL: "${GITHUB_COPILOT_CALLBACK_URL:-}"
-    labels:
-      com.datadoghq.ad.logs: '[{"source": "rust", "service": "harbangan-gateway"}]'
-      com.datadoghq.tags.env: "${DD_ENV:-production}"
-      com.datadoghq.tags.service: "harbangan-gateway"
     volumes:
       - gateway-data:/data
     deploy:
@@ -54,26 +50,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
-
-  datadog-agent:
-    image: datadog/agent:latest
-    profiles:
-      - datadog
-    restart: unless-stopped
-    environment:
-      DD_API_KEY: ${DD_API_KEY}
-      DD_SITE: ${DD_SITE:-datadoghq.com}
-      DD_ENV: ${DD_ENV:-production}
-      DD_APM_ENABLED: "true"
-      DD_APM_NON_LOCAL_TRAFFIC: "true"
-      DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: "0.0.0.0:4317"
-      DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: "0.0.0.0:4318"
-      DD_LOGS_ENABLED: "true"
-      DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: "false"
-      DD_CONTAINER_INCLUDE_LABELS: "com.datadoghq.tags.service"
-      DD_CONTAINER_EXCLUDE: "name:datadog-agent"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
 
 volumes:
   gateway-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,21 +31,14 @@ services:
       SERVER_HOST: "0.0.0.0"
       SERVER_PORT: "9999"
       DATABASE_URL: postgres://kiro:${POSTGRES_PASSWORD:-kiro_secret}@db:5432/kiro_gateway
-      DD_AGENT_HOST: datadog-agent
       GITHUB_COPILOT_CLIENT_ID: "${GITHUB_COPILOT_CLIENT_ID:-}"
       GITHUB_COPILOT_CLIENT_SECRET: "${GITHUB_COPILOT_CLIENT_SECRET:-}"
       GITHUB_COPILOT_CALLBACK_URL: "${GITHUB_COPILOT_CALLBACK_URL:-}"
       QWEN_OAUTH_CLIENT_ID: "${QWEN_OAUTH_CLIENT_ID:-}"
       INITIAL_ADMIN_EMAIL: ${INITIAL_ADMIN_EMAIL:-}
       INITIAL_ADMIN_PASSWORD: ${INITIAL_ADMIN_PASSWORD:-}
-    labels:
-      com.datadoghq.ad.logs: '[{"source": "rust", "service": "harbangan-backend"}]'
-      com.datadoghq.tags.env: "${DD_ENV:-production}"
-      com.datadoghq.tags.service: "harbangan-backend"
     depends_on:
       db:
-        condition: service_healthy
-      datadog-agent:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-fs", "http://localhost:9999/health"]
@@ -62,12 +55,6 @@ services:
     restart: unless-stopped
     ports:
       - "5173:5173"
-    environment:
-      VITE_DD_CLIENT_TOKEN: ${VITE_DD_CLIENT_TOKEN:-}
-      VITE_DD_APPLICATION_ID: ${VITE_DD_APPLICATION_ID:-}
-      VITE_DD_ENV: ${VITE_DD_ENV:-production}
-      VITE_DD_SERVICE: ${VITE_DD_SERVICE:-harbangan-frontend}
-      VITE_DD_SITE: ${VITE_DD_SITE:-datadoghq.com}
     volumes:
       - ./frontend/src:/app/src
       - ./frontend/public:/app/public
@@ -75,26 +62,5 @@ services:
       backend:
         condition: service_healthy
 
-  datadog-agent:
-    image: datadog/agent:latest
-    restart: unless-stopped
-    environment:
-      DD_API_KEY: ${DD_API_KEY}
-      DD_SITE: ${DD_SITE:-us5.datadoghq.com}
-      DD_ENV: ${DD_ENV:-production}
-      DD_APM_ENABLED: "true"
-      DD_APM_NON_LOCAL_TRAFFIC: "true"
-      DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: "0.0.0.0:4317"
-      DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: "0.0.0.0:4318"
-      DD_LOGS_ENABLED: "true"
-      DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: "true"
-      DD_CONTAINER_EXCLUDE_LOGS: "name:datadog-agent"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /proc/:/host/proc/:ro
-      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
-      - datadog-run:/opt/datadog-agent/run:rw
-
 volumes:
   pgdata:
-  datadog-run:


### PR DESCRIPTION
## Summary
- Remove `datadog-agent` service, DD labels, env vars, and volume from `docker-compose.yml` and `docker-compose.gateway.yml`
- Move DD_* vars in `.env.example` to a commented-out "Production / Kubernetes" section
- K8s cluster already runs the Datadog agent at the node level — local sidecar is redundant

## Test plan
- [x] `docker compose config --quiet` passes
- [x] `docker compose -f docker-compose.gateway.yml config --quiet` passes
- [ ] `docker compose up -d` starts cleanly without datadog-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)