### PR TITLE
chore(backend): upgrade opentelemetry ecosystem 0.27→0.31

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1404,12 +1404,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,30 +2395,28 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-datadog"
-version = "0.15.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf575cba36695d55ac2f7e4b58abdb262eba7ceeb48cc2ba47b4187e6eee5e91"
+checksum = "9a6b2d4db32343691eb945e6153e5a4bd494dbf9d931d5bf7d1d7f59bee156d0"
 dependencies = [
  "ahash",
- "futures-core",
  "http 1.4.0",
  "indexmap 2.13.0",
  "itoa",
- "once_cell",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
@@ -2432,15 +2424,15 @@ dependencies = [
  "reqwest",
  "rmp",
  "ryu",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "url",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.27.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2451,12 +2443,10 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.27.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
- "async-trait",
- "futures-core",
  "http 1.4.0",
  "opentelemetry",
  "opentelemetry-http",
@@ -2464,46 +2454,43 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
  "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.27.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
- "serde_json",
- "thiserror 1.0.69",
+ "rand 0.9.2",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
- "tracing",
 ]
 
 [[package]]
@@ -2847,9 +2834,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2857,9 +2844,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3158,7 +3145,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.0",
@@ -4321,9 +4307,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4333,11 +4319,22 @@ dependencies = [
  "http-body-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "sync_wrapper 1.0.2",
  "tokio-stream",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -4485,14 +4482,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "once_cell",
  "opentelemetry",
- "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -41,11 +41,11 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Datadog APM tracing (OpenTelemetry pipeline, enabled at runtime via DD_AGENT_HOST)
-opentelemetry = { version = "0.27", features = ["trace"] }
-opentelemetry_sdk = { version = "0.27", features = ["rt-tokio", "trace"] }
-opentelemetry-datadog = { version = "0.15", features = ["reqwest-client"] }
-opentelemetry-otlp = { version = "0.27", default-features = false, features = ["http-proto", "reqwest-rustls"] }
-tracing-opentelemetry = "0.28"
+opentelemetry = { version = "0.31", features = ["trace"] }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "trace"] }
+opentelemetry-datadog = { version = "0.19", features = ["reqwest-client"] }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["http-proto", "reqwest-rustls"] }
+tracing-opentelemetry = "0.32"
 
 # Error handling
 thiserror = "1"

--- a/backend/src/datadog.rs
+++ b/backend/src/datadog.rs
@@ -50,6 +50,7 @@ use axum::body::Body;
 use axum::http::Request;
 use axum::middleware::Next;
 use axum::response::Response;
+use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use tracing::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
@@ -126,7 +127,7 @@ pub fn dd_agent_configured() -> bool {
 ///
 /// Returns `Some(layer)` when `DD_AGENT_HOST` is set and the pipeline
 /// initialises successfully; `None` otherwise (zero overhead).
-pub fn init_datadog<S>() -> Option<OpenTelemetryLayer<S, opentelemetry_sdk::trace::Tracer>>
+pub fn init_datadog<S>() -> Option<OpenTelemetryLayer<S, opentelemetry_sdk::trace::SdkTracer>>
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {
@@ -164,16 +165,19 @@ where
 fn build_trace_pipeline<S>(
     service_name: &str,
     agent_endpoint: &str,
-) -> anyhow::Result<OpenTelemetryLayer<S, opentelemetry_sdk::trace::Tracer>>
+) -> anyhow::Result<OpenTelemetryLayer<S, opentelemetry_sdk::trace::SdkTracer>>
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {
-    let tracer = opentelemetry_datadog::new_pipeline()
+    let provider = opentelemetry_datadog::new_pipeline()
         .with_service_name(service_name)
         .with_agent_endpoint(agent_endpoint)
         .with_api_version(opentelemetry_datadog::ApiVersion::Version05)
-        .install_batch(opentelemetry_sdk::runtime::Tokio)
+        .install_batch()
         .context("Failed to install Datadog tracing pipeline")?;
+
+    let tracer = provider.tracer("harbangan");
+    opentelemetry::global::set_tracer_provider(provider);
 
     Ok(tracing_opentelemetry::layer().with_tracer(tracer))
 }
@@ -230,7 +234,7 @@ fn build_metrics_pipeline(endpoint: &str) -> anyhow::Result<SdkMeterProvider> {
         .build()
         .context("Failed to create OTLP metrics exporter")?;
 
-    let reader = PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::Tokio)
+    let reader = PeriodicReader::builder(exporter)
         .with_interval(Duration::from_secs(60))
         .build();
 
@@ -253,7 +257,8 @@ pub fn shutdown(metrics_provider: Option<&SdkMeterProvider>) {
             eprintln!("[WARN] Datadog metrics shutdown error: {e}");
         }
     }
-    opentelemetry::global::shutdown_tracer_provider();
+    // Tracer provider shutdown is handled by Drop on the global provider
+    // (set via set_tracer_provider in build_trace_pipeline)
 }
 
 #[cfg(test)]
@@ -263,7 +268,12 @@ mod tests {
     #[test]
     fn test_init_datadog_returns_none_when_no_env() {
         temp_env::with_var_unset("DD_AGENT_HOST", || {
-            let layer: Option<OpenTelemetryLayer<tracing_subscriber::Registry, _>> = init_datadog();
+            let layer: Option<
+                OpenTelemetryLayer<
+                    tracing_subscriber::Registry,
+                    opentelemetry_sdk::trace::SdkTracer,
+                >,
+            > = init_datadog();
             assert!(layer.is_none());
         });
     }
@@ -279,7 +289,12 @@ mod tests {
     #[test]
     fn test_init_datadog_returns_none_on_invalid_host() {
         temp_env::with_var("DD_AGENT_HOST", Some("http://evil@host/path"), || {
-            let layer: Option<OpenTelemetryLayer<tracing_subscriber::Registry, _>> = init_datadog();
+            let layer: Option<
+                OpenTelemetryLayer<
+                    tracing_subscriber::Registry,
+                    opentelemetry_sdk::trace::SdkTracer,
+                >,
+            > = init_datadog();
             assert!(layer.is_none());
         });
     }


### PR DESCRIPTION
## Summary
Aligned upgrade across all OpenTelemetry crates:
- **opentelemetry** 0.27→0.31
- **opentelemetry_sdk** 0.27→0.31
- **opentelemetry-otlp** 0.27→0.31
- **opentelemetry-datadog** 0.15→0.19
- **tracing-opentelemetry** 0.28→0.32

API migration in `backend/src/datadog.rs`:
- `install_batch()` no longer takes runtime arg, returns `SdkTracerProvider`
- Get tracer from provider before setting global provider
- `PeriodicReader::builder()` no longer takes runtime arg
- `shutdown_tracer_provider()` removed; `Drop` handles cleanup
- Test types updated: `Tracer`→`SdkTracer`

Supersedes Dependabot PRs #46, #49.

## Test plan
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test --lib` — 712 tests pass
- [x] `cargo fmt --check` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)