### PR TITLE
fix(frontend): correct qwen_oauth_client_id hot-reload badge

### DIFF
--- a/frontend/src/pages/Config.tsx
+++ b/frontend/src/pages/Config.tsx
@@ -160,6 +160,7 @@ const CONFIG_GROUPS: { title: string; icon: string; fields: ConfigField[] }[] =
           key: "qwen_oauth_client_id",
           label: "Qwen OAuth Client ID",
           type: "text",
+          restart: true,
         },
         {
           key: "anthropic_oauth_client_id",


### PR DESCRIPTION
## Summary
- Add `restart: true` to the `qwen_oauth_client_id` field definition in `Config.tsx` so the UI shows a "restart" badge instead of "live", matching the backend's `RequiresRestart` classification in `config_api.rs`

## Test plan
- [ ] Open Config page, verify `qwen_oauth_client_id` shows "restart" badge
- [ ] Verify `anthropic_oauth_client_id` and `openai_oauth_client_id` still show "live" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)