### PR TITLE
test(e2e): update config group count after provider OAuth migration

### DIFF
--- a/e2e-tests/specs/ui/config.spec.ts
+++ b/e2e-tests/specs/ui/config.spec.ts
@@ -10,10 +10,12 @@ const CONFIG_GROUPS = [
   'Converter',
   'HTTP Client',
   'Features',
+  'Authentication',
+  'Provider OAuth',
 ] as const
 
 test.describe('Config page', () => {
-  test('renders all 7 config groups', async ({ page }) => {
+  test('renders all 9 config groups', async ({ page }) => {
     await navigateTo(page, '/config')
 
     for (const group of CONFIG_GROUPS) {
@@ -27,7 +29,7 @@ test.describe('Config page', () => {
 
     const groups = page.locator('div.config-group')
     const count = await groups.count()
-    expect(count).toBe(7)
+    expect(count).toBe(9)
 
     // Each group should have at least one config input
     for (let i = 0; i < count; i++) {


### PR DESCRIPTION
## Summary
- Add `Authentication` and `Provider OAuth` to the `CONFIG_GROUPS` constant in `config.spec.ts` to match the 9 groups now defined in `Config.tsx` after PR #92
- Update test title from "renders all 7 config groups" to "renders all 9 config groups"
- Update `expect(count).toBe(7)` assertion to `expect(count).toBe(9)`

Fixes #97

## Test plan
- [ ] Run `npm run test:ui` in `e2e-tests/` and confirm `config.spec.ts` passes
- [ ] Verify config page renders all 9 groups in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)