### PR TITLE
chore(docker): add production deploy workflow via Tailscale + SSH

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,20 @@
+# Harbangan — Production Environment Variables
+# Copy to ~/harbangan/.env on the VPS and fill in real values.
+# chmod 600 .env
+
+# ── Required ────────────────────────────────────────────────────────
+POSTGRES_PASSWORD=changeme
+
+# Google SSO — set callback URL to your Tailscale IP
+GOOGLE_CLIENT_ID=your-google-client-id-here
+GOOGLE_CLIENT_SECRET=your-google-client-secret-here
+GOOGLE_CALLBACK_URL=http://<tailscale-ip>/_ui/api/auth/google/callback
+
+# ── Optional: password auth (alternative to Google SSO) ─────────────
+# INITIAL_ADMIN_EMAIL=admin@example.com
+# INITIAL_ADMIN_PASSWORD=changeme
+# INITIAL_ADMIN_TOTP_SECRET=your-base32-totp-secret-here
+
+# ── Optional ────────────────────────────────────────────────────────
+# CONFIG_ENCRYPTION_KEY=<openssl rand -base64 32>
+# EXTERNAL_PORT=80

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,112 @@
+name: Deploy to Production
+
+on:
+  workflow_run:
+    workflows: ["Push Docker Images"]
+    types: [completed]
+    branches: [main]
+
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy (e.g. v1.0.8)"
+        required: false
+        default: "latest"
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  BACKEND_IMAGE: ghcr.io/if414013/harbangan-backend
+  FRONTEND_IMAGE: ghcr.io/if414013/harbangan-frontend
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    # Only run if triggered manually OR if the upstream workflow succeeded on a tag
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
+
+    steps:
+      - name: Determine image tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.image_tag }}"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+          fi
+          echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Deploying tag: ${TAG}"
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Sparse checkout compose file
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: docker-compose.prod.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Copy compose file to VPS
+        run: |
+          scp -i ~/.ssh/deploy_key \
+            docker-compose.prod.yml \
+            ubuntu@${{ secrets.DEPLOY_HOST }}:~/harbangan/docker-compose.prod.yml
+
+      - name: Deploy on VPS
+        run: |
+          ssh -i ~/.ssh/deploy_key ubuntu@${{ secrets.DEPLOY_HOST }} bash -s << 'DEPLOY_SCRIPT'
+            set -euo pipefail
+            cd ~/harbangan
+
+            # Login to ghcr.io
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+            # Pull new images
+            docker pull ${{ env.BACKEND_IMAGE }}:${{ steps.tag.outputs.image_tag }}
+            docker pull ${{ env.FRONTEND_IMAGE }}:${{ steps.tag.outputs.image_tag }}
+
+            # Deploy
+            IMAGE_TAG=${{ steps.tag.outputs.image_tag }} \
+              docker compose -f docker-compose.prod.yml up -d --remove-orphans
+
+            # Wait for services to stabilize
+            echo "Waiting 30s for services to start..."
+            sleep 30
+
+            # Health checks
+            echo "Checking backend health..."
+            curl -fs http://localhost:9999/health || { echo "Backend health check failed"; exit 1; }
+
+            echo "Checking frontend health..."
+            curl -fs http://localhost/nginx-health || { echo "Frontend health check failed"; exit 1; }
+
+            echo "Deployment successful!"
+
+            # Prune old images (older than 7 days)
+            docker image prune -f --filter 'until=168h'
+
+            # Logout
+            docker logout ghcr.io
+          DEPLOY_SCRIPT
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,65 @@
+# Production deployment — pulls pre-built images from ghcr.io
+# Usage: IMAGE_TAG=v1.0.0 docker compose -f docker-compose.prod.yml up -d
+# Requires: .env file in same directory (see .env.prod.example)
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: kiro_gateway
+      POSTGRES_USER: kiro
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U kiro -d kiro_gateway"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+
+  backend:
+    image: ghcr.io/if414013/harbangan-backend:${IMAGE_TAG:-latest}
+    restart: on-failure:5
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=1
+    env_file:
+      - .env
+    environment:
+      SERVER_HOST: "0.0.0.0"
+      SERVER_PORT: "9999"
+      DATABASE_URL: postgres://kiro:${POSTGRES_PASSWORD}@db:5432/kiro_gateway
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fs", "http://localhost:9999/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+
+  frontend:
+    image: ghcr.io/if414013/harbangan-frontend:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    ports:
+      - "${EXTERNAL_PORT:-80}:80"
+    depends_on:
+      backend:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- Add `docker-compose.prod.yml` for production deployment using pre-built ghcr.io images with resource limits
- Add `.github/workflows/deploy.yml` — auto-deploys on successful `docker-push.yml` tag builds, or manual dispatch with tag input. Uses Tailscale for private network access + SSH to VPS
- Add `.env.prod.example` documenting required production environment variables

## Required GitHub Secrets
- `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET` — Tailscale OAuth client
- `DEPLOY_SSH_KEY` — Ed25519 private key for VPS access
- `DEPLOY_HOST` — Tailscale hostname/IP of VPS

## Test plan
- [ ] Configure GitHub Secrets in repo settings
- [ ] Configure Tailscale ACL for `tag:ci` → VPS SSH access
- [ ] Set up VPS: create `~/harbangan/.env` from `.env.prod.example`
- [ ] Push a test `v*` tag and verify deploy workflow triggers after image push
- [ ] Verify health checks pass (backend `/health`, frontend `/nginx-health`)
- [ ] Test manual `workflow_dispatch` rollback with a previous tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)