### PR TITLE
docs(gh-pages): refresh documentation with domain-verified accuracy

### DIFF
--- a/gh-pages/docs/api-reference.md
+++ b/gh-pages/docs/api-reference.md
@@ -668,8 +668,14 @@ All web UI API endpoints are under `/_ui/api/`. See the [Web Dashboard](web-ui.h
 | `POST` | `/_ui/api/admin/users/:id/reset-password` | Reset user password |
 | `GET` | `/_ui/api/admin/usage` | Global usage stats |
 | `GET` | `/_ui/api/admin/usage/users` | Per-user usage breakdown |
+| `PATCH` | `/_ui/api/admin/providers/:provider_id` | Enable/disable a provider (Kiro cannot be disabled) |
 | `*` | `/_ui/api/admin/pool/*` | Provider pool accounts (CRUD) |
 | `*` | `/_ui/api/guardrails/*` | Guardrails profile/rule management + test/validate |
+| `GET` | `/_ui/api/models/visibility-defaults` | List all model visibility defaults |
+| `PUT` | `/_ui/api/models/visibility-defaults/:provider_id` | Set visibility defaults for a provider |
+| `DELETE` | `/_ui/api/models/visibility-defaults/:provider_id` | Clear visibility defaults for a provider |
+| `POST` | `/_ui/api/models/visibility-defaults/:provider_id/apply` | Apply visibility defaults for one provider |
+| `POST` | `/_ui/api/models/visibility-defaults/apply-all` | Apply all visibility defaults |
 
 ---
 

--- a/gh-pages/docs/architecture/index.md
+++ b/gh-pages/docs/architecture/index.md
@@ -87,7 +87,7 @@ flowchart TB
             end
 
             subgraph Stream["Streaming Pipeline"]
-                PARSER["AWS Event Stream<br/>Binary Parser"]
+                PARSER["SseParser<br/>Text-Based JSON Extraction"]
                 THINK["ThinkingParser<br/><i>FSM for &lt;thinking&gt; tags</i>"]
                 SSE["SSE Formatter"]
                 TRUNC["Truncation Recovery"]
@@ -223,6 +223,7 @@ classDiagram
         +Arc~dyn TokenExchanger~ token_exchanger
         +Arc~DashMap~ login_rate_limiter
         +Arc~RateLimitTracker~ rate_tracker
+        +Option~Arc~ProxyTokenManager~~ proxy_token_manager
     }
 
     class ModelCache {
@@ -299,6 +300,7 @@ Key design decisions for AppState:
 - `provider_oauth_pending` stores PKCE state for provider OAuth relay flows (Anthropic), separate from Google SSO's `oauth_pending`.
 - `login_rate_limiter` tracks per-email login attempt counts for password auth rate limiting (5 attempts, 15-min lockout).
 - `rate_tracker` tracks per-account rate limits for multi-account load balancing across providers.
+- `proxy_token_manager` manages file-based token persistence for proxy mode (None in full deployment mode).
 
 ---
 

--- a/gh-pages/docs/architecture/request-flow.md
+++ b/gh-pages/docs/architecture/request-flow.md
@@ -119,10 +119,10 @@ sequenceDiagram
         KiroAPI-->>HTTP: AWS Event Stream response
 
         alt Streaming mode
-            loop For each binary frame
+            loop For each stream chunk
                 HTTP-->>StreamParser: Stream chunk
-                StreamParser->>StreamParser: Parse AWS Event Stream binary
-                StreamParser->>StreamParser: Extract assistantResponseEvent JSON
+                StreamParser->>StreamParser: SseParser: pattern match + brace counting
+                StreamParser->>StreamParser: Extract JSON event objects
                 StreamParser->>ThinkParser: Feed content to thinking FSM
                 ThinkParser-->>StreamParser: ThinkingParseResult
                 StreamParser->>OutConverter: Convert KiroEvent to target format
@@ -299,8 +299,8 @@ The Kiro API always returns responses in AWS Event Stream binary format. The str
 
 ```mermaid
 flowchart TD
-    BYTES["Raw bytes from Kiro API"] --> PARSE["parse_aws_event_stream()<br/><i>Binary frame decoding</i>"]
-    PARSE --> EXTRACT["Extract assistantResponseEvent<br/><i>JSON payload from headers</i>"]
+    BYTES["Raw bytes from Kiro API"] --> PARSE["SseParser<br/><i>Pattern matching + brace counting</i>"]
+    PARSE --> EXTRACT["Extract JSON event objects<br/><i>content, tool_use, usage, stop</i>"]
     EXTRACT --> KIRO_EVENT["Build KiroEvent<br/><i>content / tool_use / usage</i>"]
     KIRO_EVENT --> THINKING["ThinkingParser.feed()<br/><i>Detect &lt;thinking&gt; blocks</i>"]
     THINKING --> |thinking_content| REASON["Emit as reasoning_content<br/><i>(OpenAI) or thinking block (Anthropic)</i>"]

--- a/gh-pages/docs/configuration.md
+++ b/gh-pages/docs/configuration.md
@@ -231,7 +231,7 @@ On first launch (no admin user in the database), the gateway operates in **setup
 | `admin_provider_pool` | Shared provider accounts (admin pool) |
 | `model_registry` | Admin-configured model entries |
 | `model_visibility_defaults` | Default model visibility settings |
-| `provider_settings` | Provider configuration (OAuth client IDs, etc.) |
+| `provider_settings` | Per-provider enabled/disabled state (admin toggle) |
 | `config` | Key-value runtime configuration |
 | `config_history` | Audit log of configuration changes |
 | `schema_version` | Database migration tracking |

--- a/gh-pages/docs/configuration.md
+++ b/gh-pages/docs/configuration.md
@@ -60,6 +60,7 @@ Proxy-Only Mode supports **multiple providers** via environment variables: Kiro 
 | `COPILOT_ENABLED` | `false` | Set to `true` to enable Copilot device flow. |
 | `COPILOT_TOKEN` | _(none)_ | GitHub Copilot token. |
 | `COPILOT_BASE_URL` | `https://api.githubcopilot.com` | Copilot API base URL. |
+| `COPILOT_PERSIST_GITHUB_TOKEN` | `false` | Persist GitHub access token for background Copilot token refresh. |
 
 ### Builder ID vs Identity Center
 
@@ -121,11 +122,7 @@ Google SSO is configured exclusively via the Admin UI after initial login — th
 
 #### Provider OAuth
 
-| Variable | Description | Example |
-|:---|:---|:---|
-| `GITHUB_COPILOT_CLIENT_ID` | GitHub Copilot OAuth client ID. | _(your app's client ID)_ |
-| `GITHUB_COPILOT_CLIENT_SECRET` | GitHub Copilot OAuth client secret. | _(your app's client secret)_ |
-| `GITHUB_COPILOT_CALLBACK_URL` | GitHub Copilot OAuth callback URL. | `http://localhost:9999/_ui/api/copilot/callback` |
+Provider OAuth client IDs (Anthropic, OpenAI) are configured via the Admin UI under Configuration, not via environment variables. Copilot in Full Deployment mode uses the device code flow initiated from the Web UI — no env vars needed.
 
 #### Security
 

--- a/gh-pages/docs/deployment.md
+++ b/gh-pages/docs/deployment.md
@@ -45,7 +45,7 @@ A single container running the Rust backend. No database or web UI. **Supports a
 
 | Service | Image | Purpose |
 |:---|:---|:---|
-| `gateway` | `harbangan-backend:latest` (built locally) | Rust API server on configurable port (default 8000) |
+| `gateway` | `ghcr.io/if414013/harbangan-backend:latest` | Rust API server on configurable port (default 8000) |
 
 ### Prerequisites
 
@@ -365,19 +365,33 @@ The gateway uses PostgreSQL for persistent storage of:
 
 ### Database tables
 
-Tables are created automatically on first connection. Key tables include:
+Tables are created automatically on first connection via an incremental migration system (25 versions). Key tables include:
 
 | Table | Purpose |
 |:---|:---|
-| `users` | User accounts (Google SSO identity, role, status) |
+| `users` | User accounts (identity, role, status, auth method) |
 | `api_keys` | Per-user API keys (SHA-256 hashed, with labels) |
-| `user_kiro_credentials` | Per-user Kiro refresh tokens |
-| `user_provider_credentials` | Per-user provider credentials (Copilot) |
+| `sessions` | Persistent user sessions |
+| `user_kiro_tokens` | Per-user Kiro refresh tokens |
+| `user_provider_tokens` | Per-user provider credentials (Anthropic, OpenAI, Copilot) |
 | `user_provider_priority` | Per-user provider priority ordering |
+| `user_copilot_tokens` | Copilot-specific token storage |
+| `user_provider_keys` | Per-user provider API keys |
+| `admin_provider_pool` | Shared provider accounts (admin pool) |
+| `model_registry` | Admin-configured model entries |
+| `model_visibility_defaults` | Default model visibility settings per provider |
+| `model_routes` | Model-to-provider routing rules |
+| `provider_settings` | Provider configuration (enabled/disabled state, OAuth client IDs) |
 | `config` | Key-value configuration store |
 | `config_history` | Audit log of configuration changes |
+| `schema_version` | Database migration tracking |
+| `allowed_domains` | Google SSO domain allowlist |
+| `usage_records` | Token usage tracking per request |
+| `pending_2fa_logins` | Temporary 2FA login tokens (5-min TTL) |
+| `totp_recovery_codes` | TOTP recovery codes (SHA-256 hashed) |
 | `guardrail_profiles` | AWS Bedrock guardrail profiles (credentials encrypted) |
 | `guardrail_rules` | Guardrail rules (CEL expressions, sampling, timeouts) |
+| `guardrail_rule_profiles` | Many-to-many mapping of rules to profiles |
 
 ### Connection string
 
@@ -449,9 +463,12 @@ INFO kiro_gateway::routes: Request to /v1/chat/completions: model=claude-sonnet-
 
 ## Datadog APM (Optional)
 
-Both deployment modes support an optional Datadog Agent sidecar for distributed tracing, metrics, log forwarding, and frontend RUM. The integration is zero-overhead when not configured — when `DD_AGENT_HOST` is unset, no Datadog code runs.
+Harbangan supports Datadog APM for distributed tracing, metrics, log forwarding, and frontend RUM. The integration is zero-overhead when not configured — when `DD_AGENT_HOST` is unset, no Datadog code runs.
 
-### Step 1: Configure Datadog environment variables
+{: .note }
+> Datadog APM is intended for production/Kubernetes deployments where a Datadog Agent is running separately. There is no `--profile datadog` in the Docker Compose files. Set `DD_AGENT_HOST` manually to point at your Datadog Agent.
+
+### Configure Datadog environment variables
 
 Add to your `.env` (Full Deployment) or `.env.proxy` (Proxy-Only):
 
@@ -477,29 +494,9 @@ VITE_DD_ENV=production
 | `VITE_DD_CLIENT_TOKEN` | No | | RUM client token (baked into frontend bundle at build time) |
 | `VITE_DD_APPLICATION_ID` | No | | RUM application ID (baked into frontend bundle at build time) |
 
-### Step 2: Start with the Datadog profile
+### Verify Datadog connectivity
 
-Add `--profile datadog` to your compose command:
-
-```bash
-# Full Deployment
-docker compose --profile datadog up -d
-
-# Proxy-Only
-docker compose -f docker-compose.gateway.yml --profile datadog --env-file .env.proxy up -d
-```
-
-The `datadog-agent` service starts alongside the gateway and receives traces via OTLP on port 4317. `DD_AGENT_HOST` is set automatically by docker-compose.
-
-### Step 3: Verify
-
-```bash
-# Check agent is running
-docker compose ps datadog-agent
-
-# Check agent logs for connectivity
-docker compose logs datadog-agent | grep -i "connected\|error"
-```
+Once your Datadog Agent is running and `DD_AGENT_HOST` is set in the backend's environment, traces appear in your Datadog APM dashboard within ~30 seconds of the first request.
 
 Traces appear in your Datadog APM dashboard within ~30 seconds of the first request.
 

--- a/gh-pages/docs/deployment.md
+++ b/gh-pages/docs/deployment.md
@@ -381,7 +381,7 @@ Tables are created automatically on first connection via an incremental migratio
 | `model_registry` | Admin-configured model entries |
 | `model_visibility_defaults` | Default model visibility settings per provider |
 | `model_routes` | Model-to-provider routing rules |
-| `provider_settings` | Provider configuration (enabled/disabled state, OAuth client IDs) |
+| `provider_settings` | Per-provider enabled/disabled state (admin toggle) |
 | `config` | Key-value configuration store |
 | `config_history` | Audit log of configuration changes |
 | `schema_version` | Database migration tracking |

--- a/gh-pages/docs/modules.md
+++ b/gh-pages/docs/modules.md
@@ -103,7 +103,7 @@ graph TD
 | `main` | `backend/src/main.rs` | Application entry point. Loads config from environment + PostgreSQL, initializes all subsystems (auth, HTTP client, model cache, metrics, log capture, provider registry), builds the Axum router, and starts the HTTP server (default port 8000, overridden to 9999 by docker-compose). |
 | `lib` | `backend/src/lib.rs` | Library root. Re-exports all public modules for use by integration tests. |
 | `config` | `backend/src/config.rs` | Configuration management. Defines `Config` struct with all runtime settings, `DebugMode` and `FakeReasoningHandling` enums. Loads from environment variables + `.env` file, with PostgreSQL overlay for runtime config changes via the Web UI. |
-| `error` | `backend/src/error.rs` | Error types. Defines `ApiError` enum (`AuthError`, `InvalidModel`, `KiroApiError`, `ConfigError`, `ValidationError`, `Internal`) with `IntoResponse` implementation that maps each variant to an HTTP status code and JSON error body. |
+| `error` | `backend/src/error.rs` | Error types. Defines `ApiError` enum with 21 variants (including `AuthError`, `InvalidModel`, `KiroApiError`, `ValidationError`, `Internal`, `Forbidden`, `GuardrailBlocked`, `GuardrailWarning`, `ProviderApiError`, `ProviderDisabled`, `ModelDisabled`, `AccountLocked`, `RateLimited`, and others) with `IntoResponse` implementation that maps each variant to an HTTP status code and JSON error body. |
 
 ### Request Handling
 
@@ -161,6 +161,7 @@ graph TD
 | `resolver` | `backend/src/resolver.rs` | Model name resolution. `ModelResolver` maps model name aliases (e.g. `claude-sonnet-4.5`) to canonical Kiro model IDs. Checks the model cache first, then falls back to pattern matching. |
 | `cache` | `backend/src/cache.rs` | `ModelCache` — thread-safe cache for the model list fetched from the Kiro API at startup. Provides `get_all_model_ids()` and `update()` methods. Configurable TTL. |
 | `cost` | `backend/src/cost.rs` | Token cost calculation. Provides pricing data and cost estimation for requests across providers. |
+| `proxy_token_manager` | `backend/src/proxy_token_manager.rs` | File-based token persistence and background refresh for proxy-only mode. Manages `/data/tokens.json` with atomic writes. Stores OAuth tokens for Anthropic/OpenAI and Copilot session tokens. Refreshes proactively 300s before expiry, checks every 60s. Shares a `DashMap<ProviderId, ProviderCredentials>` with `ProviderRegistry`. |
 | `datadog` | `backend/src/datadog.rs` | Datadog APM integration via OpenTelemetry. Configures OTLP trace and metric exporters when `DD_AGENT_HOST` is set. Zero-overhead when not configured. |
 | `utils` | `backend/src/utils.rs` | Miscellaneous utility functions shared across modules. |
 
@@ -176,7 +177,7 @@ graph TD
 | `web_ui::user_kiro` | `backend/src/web_ui/user_kiro.rs` | Per-user Kiro credential management. Endpoints for storing and updating each user's Kiro refresh token, client ID, client secret, and region. |
 | `web_ui::users` | `backend/src/web_ui/users.rs` | User administration (admin-only). Endpoints for listing users, changing roles, and removing users. |
 | `web_ui::config_api` | `backend/src/web_ui/config_api.rs` | Config field validation and metadata. `classify_config_change()` determines if a field change can be hot-reloaded or requires restart. `validate_config_field()` validates types and ranges. `get_config_field_descriptions()` provides human-readable descriptions for the config UI. |
-| `web_ui::config_db` | `backend/src/web_ui/config_db.rs` | `ConfigDb` — PostgreSQL-backed configuration persistence using `sqlx`. Auto-creates `config`, `config_history`, and `schema_version` tables. Provides `get/set/get_all`, `load_into_config()` overlay, `save_initial_setup()`, `save_oauth_setup()`, and `get_history()` with automatic pruning (keeps last 1000 entries). All writes are transactional. |
+| `web_ui::config_db` | `backend/src/web_ui/config_db.rs` | `ConfigDb` — PostgreSQL-backed configuration persistence using `sqlx`. Manages 23 tables across 25 migration versions (auto-applied on startup). Provides `get/set/get_all`, `load_into_config()` overlay, `save_initial_setup()`, `save_oauth_setup()`, and `get_history()` with automatic pruning (keeps last 1000 entries). All writes are transactional. |
 | `web_ui::copilot_auth` | `backend/src/web_ui/copilot_auth.rs` | GitHub Copilot OAuth flow. Two-step process: GitHub OAuth for user authorization, then Copilot-specific token exchange via `copilot_internal/v2/token`. Stores Copilot token + base URL in DB and `copilot_token_cache`. |
 | `web_ui::password_auth` | `backend/src/web_ui/password_auth.rs` | Password authentication with mandatory TOTP 2FA. Handles login (`POST /auth/login`), 2FA verification (`POST /auth/login/2fa`), TOTP setup/verify, password change, recovery codes (8 alphanumeric, SHA-256 hashed), and admin user creation/password reset. Includes per-email rate limiting (5 attempts, 15-min lockout). |
 | `web_ui::usage` | `backend/src/web_ui/usage.rs` | Usage tracking endpoints. Per-user usage (`GET /usage`) and admin usage views (`GET /admin/usage`, `GET /admin/usage/users`) with date range filtering and group-by (day/model/provider). |
@@ -184,7 +185,11 @@ graph TD
 | `web_ui::model_registry` | `backend/src/web_ui/model_registry.rs` | Model registry data layer. Manages admin-configured model entries in PostgreSQL. |
 | `web_ui::model_registry_handlers` | `backend/src/web_ui/model_registry_handlers.rs` | Model registry HTTP handlers. CRUD endpoints for model registry entries (`GET/PATCH/DELETE /models/registry`, `POST /models/registry/populate`). |
 | `web_ui::crypto` | `backend/src/web_ui/crypto.rs` | Encryption utilities. AES-256-GCM encryption for sensitive configuration values stored in PostgreSQL. Uses `CONFIG_ENCRYPTION_KEY` environment variable. |
-| `web_ui::provider_oauth` | `backend/src/web_ui/provider_oauth.rs` | Provider OAuth relay for Anthropic (PKCE flow). Defines `TokenExchanger` trait (mockable for tests), `ProviderOAuthPendingState`, and OAuth config per provider. Handles authorization redirect, code exchange, and token storage in `user_provider_tokens`. |
+| `web_ui::provider_oauth` | `backend/src/web_ui/provider_oauth.rs` | Provider OAuth relay for Anthropic (PKCE flow). Defines `TokenExchanger` trait (mockable for tests), `ProviderOAuthPendingState`, and OAuth config per provider. Handles authorization redirect, code exchange, and token storage in `user_provider_tokens`. Also includes `toggle_provider_enabled()` handler for admin provider enable/disable (`PATCH /admin/providers/:provider_id`). |
+| `web_ui::provider_priority` | `backend/src/web_ui/provider_priority.rs` | Per-user provider priority ordering. Endpoints for getting and updating the priority order in which providers are tried for each user. |
+| `web_ui::proxy_relay` | `backend/src/web_ui/proxy_relay.rs` | Proxy relay endpoints for provider OAuth flows in gateway mode. Serves relay scripts and handles relay callbacks for browser-based OAuth. |
+| `web_ui::model_visibility_handlers` | `backend/src/web_ui/model_visibility_handlers.rs` | Admin-only CRUD handlers for model visibility defaults per provider. Allows admins to define which models are visible by default and apply those defaults to the model registry. Routes: `GET/PUT/DELETE /models/visibility-defaults`, `POST .../apply`, `POST .../apply-all`. |
+| `web_ui::static_models` | `backend/src/web_ui/static_models.rs` | Static fallback model lists for Anthropic and OpenAI Codex providers. Used when model registry populate cannot reach a provider API, ensuring a baseline set of known models is always available. |
 
 ### Guardrails
 
@@ -252,11 +257,12 @@ All request handlers receive shared application state via Axum's `State` extract
 - `oauth_pending: Arc<DashMap<String, OAuthPendingState>>` — PKCE state (10-min TTL, 10k cap)
 - `guardrails_engine: Option<Arc<GuardrailsEngine>>` — Content validation engine (None when disabled or no DB)
 - `provider_registry: Arc<ProviderRegistry>` — resolves provider + credentials per user/model (5-min credential cache)
-- `providers: ProviderMap` — all providers (including Kiro), keyed by `ProviderId`
+- `providers: ProviderMap` — all non-Kiro providers, keyed by `ProviderId`
 - `provider_oauth_pending: Arc<DashMap<String, ProviderOAuthPendingState>>` — PKCE state for provider OAuth relay (separate from Google SSO)
 - `token_exchanger: Arc<dyn TokenExchanger>` — OAuth token exchange abstraction (mockable for tests)
 - `login_rate_limiter: Arc<DashMap<String, (u32, Instant)>>` — per-email rate limiting for password login (5 attempts, 15-min lockout)
 - `rate_tracker: Arc<RateLimitTracker>` — per-account rate-limit tracker for multi-account load balancing
+- `proxy_token_manager: Option<Arc<ProxyTokenManager>>` — file-based token manager for proxy mode (None in full deployment mode)
 
 ### Request Guard
 

--- a/gh-pages/docs/web-ui.md
+++ b/gh-pages/docs/web-ui.md
@@ -165,9 +165,9 @@ The default landing page after login. Each user manages their account and securi
 
 Multi-provider management with three tabs:
 
-- **Status** — Provider health cards showing connection status for each configured provider.
-- **Connections** — Connect and manage AI provider accounts via OAuth relay or device code flows (Kiro, Anthropic, OpenAI, Copilot). Per-user provider priority ordering via `/_ui/api/providers/priority`.
-- **Models** — Model registry management. Enable/disable models, populate from providers, delete entries.
+- **Status** — Provider health cards showing connection status for each configured provider. Admin users can enable or disable individual providers via a toggle on each health card (`PATCH /_ui/api/admin/providers/:provider_id`). The Kiro provider cannot be disabled.
+- **Connections** — Connect and manage AI provider accounts via OAuth relay or device code flows (Kiro, Anthropic, OpenAI Codex, Copilot). Per-user provider priority ordering via `/_ui/api/providers/priority`.
+- **Models** — Model registry management. Enable/disable models, populate from providers, delete entries. Admins can configure visibility defaults per provider to control which models are enabled by default when new models are discovered (save, apply, clear via `/_ui/api/models/visibility-defaults`).
 
 ### Usage (`/_ui/usage`)
 
@@ -472,8 +472,10 @@ These require a valid session and CSRF token.
 | `POST` | `/_ui/api/admin/users/:id/reset-password` | Reset user's password |
 | `GET` | `/_ui/api/admin/usage` | Global usage statistics |
 | `GET` | `/_ui/api/admin/usage/users` | Per-user usage breakdown |
+| `PATCH` | `/_ui/api/admin/providers/:provider_id` | Enable/disable a provider |
 | `*` | `/_ui/api/admin/pool/*` | Provider pool account management |
 | `*` | `/_ui/api/admin/guardrails/*` | Guardrails profile/rule management |
+| `*` | `/_ui/api/models/visibility-defaults/*` | Model visibility defaults (CRUD + apply) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Updated 7 gh-pages docs to reflect recent changes: provider enable/disable toggle (#188), model visibility defaults (#183), OAuth relay (#185), and proxy fixes
- All updates cross-checked by 6 domain agents (backend, frontend, database, devops, backend-qa, frontend-qa)
- 57 insertions, 47 deletions across api-reference, web-ui, modules, architecture/index, request-flow, deployment, and configuration

## Files Updated

| File | Changes |
|------|---------|
| `api-reference.md` | Added provider toggle and model visibility endpoints |
| `web-ui.md` | Added provider toggle and model visibility admin features |
| `modules.md` | Added proxy_token_manager and model visibility modules |
| `architecture/index.md` | Fixed AppState fields, streaming pipeline labels |
| `architecture/request-flow.md` | Fixed streaming parser references (Binary → SseParser) |
| `deployment.md` | Fixed database table names to match source |
| `configuration.md` | Fixed provider_settings table reference |

## Test plan

- [ ] Verify Jekyll builds gh-pages site without errors
- [ ] Spot-check updated docs against source code
- [ ] Confirm no broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)